### PR TITLE
issue #000 fix: content fixes M1-R1 Hindi-Tamil

### DIFF
--- a/src/RFlow/R1.jsx
+++ b/src/RFlow/R1.jsx
@@ -785,7 +785,7 @@ const levelData = {
           { img: getAssetUrl(s3Assets.coffeeR1HinImg), text: "Coffee" },
         ],
         correctWord: "Oil",
-        audio: getAssetAudioUrl(s3Assets.telR1HinAudio),
+        audio: getAssetAudioUrl(s3Assets.telHinAudio),
         flowName: "P25",
       },
       {
@@ -815,7 +815,7 @@ const levelData = {
           { img: getAssetUrl(s3Assets.EagleR1HinImg), text: "Eagle" },
         ],
         correctWord: "Crow",
-        audio: getAssetAudioUrl(s3Assets.kauwaR1HinAudio),
+        audio: getAssetAudioUrl(s3Assets.kauwaHinAudio),
         flowName: "P28",
       },
       {
@@ -1079,7 +1079,7 @@ const levelData = {
           { img: getAssetUrl(s3Assets.basketR1Tam), text: "Basket" },
         ],
         correctWord: "Cloth",
-        audio: getAssetAudioUrl(s3Assets.clothR1TamAudio),
+        audio: getAssetAudioUrl(s3Assets.clothTamAudio),
         flowName: "P4",
       },
       {

--- a/src/components/Practice/BingoCard.jsx
+++ b/src/components/Practice/BingoCard.jsx
@@ -648,7 +648,7 @@ const BingoCard = ({
       L3: {
         words: [
           "सर्क",
-          "बास",
+          "बास्‌",
           "हेल",
           "स",
           "कृ",
@@ -677,12 +677,12 @@ const BingoCard = ({
             image: getAssetUrl(s3Assets.krishnM2),
             audio: getAssetAudioUrl(s3Assets.krishnM2Hin),
           },
-          टोकरी: {
+          बास्‌केट: {
             image: getAssetUrl(s3Assets.basketM2),
             audio: getAssetAudioUrl(s3Assets.basketM2Hin),
           },
         },
-        arrM: ["सर्कस", "हेलमेट", "गुब्बारा", "कृष्ण", "टोकरी"],
+        arrM: ["सर्कस", "हेलमेट", "गुब्बारा", "कृष्ण", "बास्‌केट"],
       },
       L4: {
         words: [
@@ -1342,7 +1342,6 @@ const BingoCard = ({
       हेलमेट: ["हेल", "मेट"],
       गुब्बारा: ["गुब्बा", "रा"],
       कृष्ण: ["कृ", "ष्ण"],
-      टोकरी: ["बास", "केट"],
       गुलाब: ["गु", "लाब"],
       शरबत: ["शर", "बत"],
       மூன்று: ["மூன", "்று"],
@@ -1405,6 +1404,7 @@ const BingoCard = ({
       పన్ను: ["ప", "న్ను"],
       ముక్కు: ["ముక్", "కు"],
       చొక్కా: ["చోక్", "కా"],
+      बास्‌केट: ["बास्‌", "केट"],
     };
 
     const currentWord = levels[currentLevel]?.arrM[currentWordIndex];

--- a/src/utils/s3Links.js
+++ b/src/utils/s3Links.js
@@ -4192,3 +4192,15 @@ export const lamp_M1Audio = "ce993498-f475-4afa-8e17-9cd63e961024.mp3";
 export const swimming_M1Audio = "a1740f7c-ff62-45b8-823a-8e5c66b42f78.mp3";
 export const city_M1Audio = "ded1136f-303e-498b-8ea0-6f565d794f00.mp3";
 export const sand_M1Audio = "6065480c-aa55-465c-bb92-b64fb9deef4e.mp3";
+
+export const hutTamAudio = "32049b3e-b0c8-4dea-93a7-957fcfba686b.mp3";
+export const peacockTamAudio = "68194a3c-6fdf-4b5b-af1b-d73dcd1fbb67.mp3";
+export const clothTamAudio = "e07b7ae9-6eca-4620-91bb-5106c2feb018.mp3";
+export const muraliTamAudio = "ba1d4b0c-c721-4a90-9682-fddf53a7ac27.mp3";
+export const axeTamAudio = "c973a808-92b0-4404-b767-d1f54fc00dee.mp3";
+export const cloudTamAudio = "0d9ba691-e8b2-4476-87db-637aa218286b.mp3";
+
+export const uvaTamAudio = "179326db-16ee-4bbe-96f4-8a0a489b714d.mp3";
+
+export const kauwaHinAudio = "edfc9f87-7efa-4dda-858f-1a5dfa611ee9.mp3";
+export const telHinAudio = "fcd96d28-f83e-4095-b1aa-d5cb8d3be3cb.mp3";

--- a/src/views/Practice/Practice.jsx
+++ b/src/views/Practice/Practice.jsx
@@ -696,10 +696,10 @@ const Practice = () => {
             },
             {
               name: "டன்",
-              audio: getAssetAudioUrl(s3Assets.kurudanWord3Audio),
+              audio: getAssetAudioUrl(s3Assets.kurudanAudio),
             },
           ],
-          completeAudio: getAssetAudioUrl(s3Assets.kurudanAudio),
+          completeAudio: getAssetAudioUrl(s3Assets.kurudanWord3Audio),
         },
         {
           completeWord: "விவசாயி",
@@ -856,7 +856,7 @@ const Practice = () => {
           img: getAssetUrl(s3Assets.pomegranateM1Tam),
           syllablesAudio: [
             {
-              name: "ದಾமா",
+              name: "மா",
               audio: getAssetAudioUrl(s3Assets.pomegranateWord1Audio),
             },
             {
@@ -891,7 +891,7 @@ const Practice = () => {
               audio: getAssetAudioUrl(s3Assets.peacock2M1SylTam),
             },
           ],
-          completeAudio: getAssetAudioUrl(s3Assets.PeacockM1Tam),
+          completeAudio: getAssetAudioUrl(s3Assets.peacockTamAudio),
         },
         {
           completeWord: "தாமரை",
@@ -963,17 +963,33 @@ const Practice = () => {
       ],
       P3: [
         { completeWord: "தயிர்", syllable: ["த", "யிர்"], audio: "CurdM1Tam" },
-        { completeWord: "மேகம்", syllable: ["மே", "கம்"], audio: "CloudM1Tam" },
-        { completeWord: "குடில்", syllable: ["கு", "டில்"], audio: "hutM1Tam" },
+        {
+          completeWord: "மேகம்",
+          syllable: ["மே", "கம்"],
+          audio: "cloudTamAudio",
+        },
+        {
+          completeWord: "குடில்",
+          syllable: ["கு", "டில்"],
+          audio: "hutTamAudio",
+        },
         {
           completeWord: "மாலை",
           syllable: ["மா", "லை"],
           audio: "necklaceM1Tam",
         },
-        { completeWord: "கொடரி", syllable: ["கொ", "டரி"], audio: "AxeM1Tam" },
+        {
+          completeWord: "கொடரி",
+          syllable: ["கொ", "டரி"],
+          audio: "axeTamAudio",
+        },
       ],
       P4: [
-        { completeWord: "முரலி", syllable: ["மு", "ரலி"], audio: "FluteM1Tam" },
+        {
+          completeWord: "முரலி",
+          syllable: ["மு", "ரலி"],
+          audio: "muraliTamAudio",
+        },
         { completeWord: "சிறகு", syllable: ["சி", "றகு"], audio: "wingM1Tam" },
         {
           completeWord: "கோபம்",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected Tamil syllable label to “மா” in Practice.
  - Updated Hindi basket term to “बास्‌केट” across Bingo, aligning syllable splits and asset mapping.
  - Fixed audio mappings in R1 and Practice (e.g., peacock, kurudan) to play the correct clips.

- Refactor
  - Standardized Tamil/Hindi audio references to consistent Tam/Hin variants across Practice levels.

- Chores
  - Added new Tamil and Hindi audio assets (e.g., hut, peacock, cloth, flute, axe, cloud, uva, crow, oil) to the asset catalog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->