### PR TITLE
Revert "issue #000 feat: Word Wall & Word Practice data for Showcase flows"

### DIFF
--- a/src/components/Mechanism/WordsOrImage.jsx
+++ b/src/components/Mechanism/WordsOrImage.jsx
@@ -12,7 +12,6 @@ import VoiceAnalyser from "../../utils/VoiceAnalyser";
 import RecordVoiceVisualizer from "../../utils/RecordVoiceVisualizer";
 import hintsImg from "../../assets/hints.svg";
 import {
-  practiceSteps,
   PlayAudioButton,
   StopAudioButton,
   ListenButton,
@@ -137,45 +136,8 @@ const WordsOrImage = ({
   } = useSpeechRecognition();
   const [showWrongTick, setShowWrongTick] = useState(true);
   const [isTranscriptCorrect, setIsTranscriptCorrect] = useState(null);
-  const sessionId = getLocalData("sessionId");
-  const correctShowcaseWords = getLocalData("correctShowcaseWords");
-
-  let progressDatas = getLocalData("practiceProgress");
-  //const virtualId = String(getLocalData("virtualId"));
-
-  if (typeof progressDatas === "string") {
-    progressDatas = JSON.parse(progressDatas);
-  }
-
-  let currentPracticeStep;
-  if (progressDatas) {
-    currentPracticeStep = progressDatas?.currentPracticeStep;
-  }
-
-  let currentLevel = practiceSteps?.[currentPracticeStep]?.title || "L1";
 
   const handleNextWrapped = () => {
-    if (
-      [1, 2]?.includes(level) &&
-      (currentLevel === "S1" || currentLevel === "S2")
-    ) {
-      const newWordData = {
-        original_text: words,
-        content_id: contentId,
-        milestone_level: level === 1 ? "m1" : level === 2 ? "m2" : "m3",
-        practice_level: currentLevel,
-        session_id: sessionId,
-        practiced: true,
-        learned: true,
-        subsession_id: "session_123",
-      };
-
-      setLocalData("correctShowcaseWords", [
-        ...(correctShowcaseWords || []),
-        newWordData,
-      ]);
-    }
-
     setIsTranscriptCorrect(null);
     handleNext();
   };

--- a/src/services/orchestration/orchestrationService.js
+++ b/src/services/orchestration/orchestrationService.js
@@ -97,34 +97,6 @@ export const addCorrectPracticeWords = async () => {
   }
 };
 
-export const addCorrectShowcaseWords = async () => {
-  const correctShowcaseWords = getLocalData("correctShowcaseWords");
-  const token = localStorage.getItem("apiToken");
-
-  if (!correctShowcaseWords || correctShowcaseWords.length === 0) {
-    console.warn("No correct showcase words to send.");
-    return;
-  }
-
-  try {
-    const response = await axios.post(
-      `${API_LEARNER_AI_APP_HOST}/api/towre/addCorrectWord`,
-      { correctShowcaseWords },
-      {
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
-        },
-      }
-    );
-
-    return response.data;
-  } catch (error) {
-    console.error("Error sending correctPracticeWords:", error);
-    throw error;
-  }
-};
-
 export const updateCorrectPracticeWords = async (updates) => {
   const token = localStorage.getItem("apiToken");
 

--- a/src/views/Practice/Practice.jsx
+++ b/src/views/Practice/Practice.jsx
@@ -57,7 +57,6 @@ import {
   addLesson,
   addPointer,
   addCorrectPracticeWords,
-  addCorrectShowcaseWords,
   fetchUserPoints,
   createLearnerProgress,
   getLessonProgressByID,
@@ -4565,9 +4564,6 @@ const Practice = () => {
           }
 
           if (getSetData.sessionResult === "pass") {
-            if (level === 1 || level === 2) {
-              const addCorrectWords = await addCorrectShowcaseWords();
-            }
             if (
               level === 15 &&
               (currentLevel === "S1" || currentLevel === "S2")
@@ -4973,7 +4969,6 @@ const Practice = () => {
   useEffect(() => {
     fetchDetails();
     setLocalData("correctPracticeWords", null);
-    setLocalData("correctShowcaseWords", null);
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
Reverts Sunbird-ALL/all-learner-ai-app#474

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the post-answer flow in Words or Image: resets answer state and moves to the next item without showcase-word progress steps or session milestones.
  * Streamlined Practice view by removing reliance on showcase-word submission logic and clearing only practice-word data on load.

* **Chores**
  * Removed the unused backend submission for “correct showcase words” and related imports, reducing complexity and network calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->