### PR TITLE
issue #000 feat: Add Recommendation api only for english

### DIFF
--- a/src/views/Practice/Practice.jsx
+++ b/src/views/Practice/Practice.jsx
@@ -4477,7 +4477,8 @@ const Practice = () => {
 
       const getContentFn = currentGetContent?.mechanism
         ? getContent
-        : process.env.REACT_APP_USE_RECOMMENDATION_API === "true"
+        : process.env.REACT_APP_USE_RECOMMENDATION_API === "true" &&
+          lang === "en"
         ? getContentNew
         : getContent;
 
@@ -4886,7 +4887,8 @@ const Practice = () => {
 
       const getContentFn = currentGetContent?.mechanism
         ? getContent
-        : process.env.REACT_APP_USE_RECOMMENDATION_API === "true"
+        : process.env.REACT_APP_USE_RECOMMENDATION_API === "true" &&
+          lang === "en"
         ? getContentNew
         : getContent;
 
@@ -5018,7 +5020,8 @@ const Practice = () => {
 
       const getContentFn = currentGetContent?.mechanism
         ? getContent
-        : process.env.REACT_APP_USE_RECOMMENDATION_API === "true"
+        : process.env.REACT_APP_USE_RECOMMENDATION_API === "true" &&
+          lang === "en"
         ? getContentNew
         : getContent;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted content routing so recommendations are only used for English when the recommendations setting is enabled.
  * Non-English users now reliably receive standard content, improving consistency and avoiding unintended recommendation usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->