### PR TITLE
Remove “Register” Link from Login Page

### DIFF
--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -66,12 +66,12 @@ const routData = [
     component: reviews.LoginPage,
     requiresAuth: false,
   },
-  {
-    id: "route-011",
-    path: "/register",
-    component: reviews.RegisterPage,
-    requiresAuth: false,
-  },
+  // {
+  //   id: "route-011",
+  //   path: "/register",
+  //   component: reviews.RegisterPage,
+  //   requiresAuth: false,
+  // },
 ];
 // add login route for test rig
 const TOKEN = localStorage.getItem("apiToken");

--- a/src/views/LoginPage/LoginPage.jsx
+++ b/src/views/LoginPage/LoginPage.jsx
@@ -238,7 +238,7 @@ const LoginPage = () => {
             </Grid>
 
             {/* Register Link */}
-            {activeTab === 0 && (
+            {/* {activeTab === 0 && (
               <Grid item xs={12}>
                 <Typography variant="body1" align="center">
                   Don’t have an account?{" "}
@@ -255,7 +255,7 @@ const LoginPage = () => {
                   </Link>
                 </Typography>
               </Grid>
-            )}
+            )} */}
           </Grid>
         </form>
       </div>


### PR DESCRIPTION
Removed the "**Register**" link from the login page to prevent users from navigating to the registration page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Disabled the /register route; the Register page is no longer accessible.
  - Removed the Register link from the Login page (Student tab), hiding registration entry points in the UI.
  - All other routes and login behavior remain unchanged.

- Refactor
  - Commented out registration-related UI and route entries without altering surrounding logic or layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->