### PR TITLE
Issue #0000 fix: updated the letter launcher time from 70 sec to 90sec

### DIFF
--- a/src/components/Practice/LetterLauncher.jsx
+++ b/src/components/Practice/LetterLauncher.jsx
@@ -154,7 +154,7 @@ const LetterLauncher = ({
 
   const handleStart = () => {
     setIsPlaying(true);
-    setTimeRemaining(70);
+    setTimeRemaining(90);
     setCorrectCount(0);
     setWrongCount(0);
     setCurrentItemIndex(0);
@@ -265,7 +265,7 @@ const LetterLauncher = ({
     setScore(0);
     setIsComplete(false);
     setIsPlaying(false);
-    setTimeRemaining(70);
+    setTimeRemaining(90);
     if (items.length > 0) {
       setCurrentItem(items[0]);
     }

--- a/src/components/Practice/LetterLauncherMechanics.jsx
+++ b/src/components/Practice/LetterLauncherMechanics.jsx
@@ -279,7 +279,7 @@ const LetterLauncherMechanicsContent = ({
 
   const [questions, setQuestions] = useState([]);
   const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
-  const [timeRemaining, setTimeRemaining] = useState(70);
+  const [timeRemaining, setTimeRemaining] = useState(90);
   const [isTimerRunning, setIsTimerRunning] = useState(false);
   const [showLetter, setShowLetter] = useState(false);
   const [isPlayingAudio, setIsPlayingAudio] = useState(false);
@@ -438,7 +438,7 @@ const LetterLauncherMechanicsContent = ({
     ) {
       // Start the timer for Apply steps when game begins
       setIsTimerRunning(true);
-      setTimeRemaining(70);
+      setTimeRemaining(90);
     }
   }, [
     effectiveIsShowCase,
@@ -1018,7 +1018,7 @@ const LetterLauncherMechanicsContent = ({
     setQuestionSummaries([]);
     setLevelStartTime(Date.now());
     setIsTimerRunning(false);
-    setTimeRemaining(70);
+    setTimeRemaining(90);
     const newQuestions = generateQuestions();
     setQuestions(newQuestions);
     if (effectiveIsShowCase) {


### PR DESCRIPTION
Issue #0000 fix: updated the letter launcher time from 70 sec to 90sec

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended timer duration for letter practice activities from 70 to 90 seconds, providing users with additional time to complete exercises and retry attempts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->