### PR TITLE
IssueId #0000 fix : getting syllable audio instead of word audio in M1

### DIFF
--- a/src/components/Practice/Mechanics7.jsx
+++ b/src/components/Practice/Mechanics7.jsx
@@ -281,7 +281,7 @@ const Mechanics7 = ({
   //   ? currentImg?.completeWord
   //   : currentImg?.syllablesAudio?.[stepIndex]?.name || "";
 
-  const currentAudio = parentWords?.syllable?.[stepIndex]?.audio_url || null;
+  const currentAudio = currentImg?.audioUrl || null;
   const [stepsIndex, setStepsIndex] = useState(0);
 
   //console.log("wordSyl", currentText);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio playback functionality in the practice module to ensure correct audio sources are accessed during syllable practice.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->