### PR TITLE
IssueId #253762 fix : addLesson issue in M1 of milestone type and progress issue

### DIFF
--- a/src/RFlow/SoundHuntS1Combined.jsx
+++ b/src/RFlow/SoundHuntS1Combined.jsx
@@ -4805,15 +4805,15 @@ const SoundHuntS1Combined = ({
             // Calculate progress (S1 is a showcase step)
             const totalSteps = practiceSteps.length;
             const progress = Math.round(
-              ((stepIndex + 1) / (totalSteps * (steps || 1))) * 100
+              (Math.min(stepIndex + 2, totalSteps) / totalSteps) * 100
             );
 
             try {
               await addLesson({
                 sessionId: sessionId,
-                milestone: "showcase", // S1 is a showcase step
+                milestone: "practice", // S1 is a showcase step
                 lesson: stepIndex == 9 ? 0 : stepIndex + 1,
-                progress: Math.min(100, progress),
+                progress: stepIndex == 9 ? 0 : Math.min(100, progress),
                 language: lang,
                 milestoneLevel: milestoneLevel,
               });

--- a/src/views/Practice/Practice.jsx
+++ b/src/views/Practice/Practice.jsx
@@ -6293,9 +6293,16 @@ const Practice = () => {
           isF3FlowByMilestone; // F3 flow always handles its own progress
 
         if (!shouldSkipAddLesson) {
+          // Determine milestone type based on the NEXT step (newPracticeStep), not the current step
+          // This ensures that when P2 completes and next is S1, milestone is "showcase"
+          const nextStepTitle = practiceSteps?.[newPracticeStep]?.title || "";
+          const nextStepMilestoneType = ["S1", "S2"].includes(nextStepTitle)
+            ? "showcase"
+            : "practice";
+
           await addLesson({
             sessionId: sessionId,
-            milestone: milestoneType,
+            milestone: nextStepMilestoneType,
             lesson: newPracticeStep,
             progress: currentPracticeProgress,
             language: lang,


### PR DESCRIPTION
- M1-P2-->On Completeion addLesson is added of lesson 4 as next is S1 , milestone should be showcase but going as practice
- M1-s1--> On Completion , on Fail addLesson is added  of lesson 5 and milestone as showcase but it need to go as practice as L3 is practice and progress went as 3 - telugu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved progress calculation accuracy for lesson attempts with refined formulas for failure scenarios
  * Enhanced milestone tracking to better align with lesson progression flow
  * Updated milestone assignment to reference upcoming lesson steps instead of current steps for more accurate progress reporting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->