### PR TITLE
IssueId #253672 Fix : M4 -M9  in telemetry showing incorrect level .

### DIFF
--- a/src/components/Practice/FluencyP1.jsx
+++ b/src/components/Practice/FluencyP1.jsx
@@ -389,6 +389,11 @@ const FluencyP1 = ({
 
   let apiLevel = `M${level}-${currentLevel}`;
 
+  if (level >= 4 && level <= 9) {
+    currentLevel = practiceSteps?.[currentPracticeStep]?.name;
+    apiLevel = `M${level}-${currentLevel}`;
+  }
+
   useEffect(() => {
     handleStart();
   }, [parentWords]);

--- a/src/components/Practice/FluencyP2.jsx
+++ b/src/components/Practice/FluencyP2.jsx
@@ -292,8 +292,13 @@ const FluencyP2 = ({
     currentPracticeStep = progressDatas?.currentPracticeStep;
   }
 
-  const currentLevel = practiceSteps?.[currentPracticeStep]?.titleNew || "L1";
+  let currentLevel = practiceSteps?.[currentPracticeStep]?.titleNew || "L1";
   let apiLevel = `M${level}-${currentLevel}`;
+
+  if (level >= 4 && level <= 9) {
+    currentLevel = practiceSteps?.[currentPracticeStep]?.name;
+    apiLevel = `M${level}-${currentLevel}`;
+  }
 
   const callTelemetry = async () => {
     const sessionId = getLocalData("sessionId");

--- a/src/components/Practice/FluencyP3.jsx
+++ b/src/components/Practice/FluencyP3.jsx
@@ -244,8 +244,13 @@ const FluencyP3 = ({
     currentPracticeStep = progressDatas?.currentPracticeStep;
   }
 
-  const currentLevel = practiceSteps?.[currentPracticeStep]?.titleNew || "L1";
+  let currentLevel = practiceSteps?.[currentPracticeStep]?.titleNew || "L1";
   let apiLevel = `M${level}-${currentLevel}`;
+
+  if (level >= 4 && level <= 9) {
+    currentLevel = practiceSteps?.[currentPracticeStep]?.name;
+    apiLevel = `M${level}-${currentLevel}`;
+  }
 
   const callTelemetry = async () => {
     const sessionId = getLocalData("sessionId");

--- a/src/components/Practice/FluencyP4.jsx
+++ b/src/components/Practice/FluencyP4.jsx
@@ -482,8 +482,13 @@ const FluencyP4 = ({
     currentPracticeStep = progressDatas?.currentPracticeStep;
   }
 
-  const currentLevel = practiceSteps?.[currentPracticeStep]?.titleNew || "L1";
+  let currentLevel = practiceSteps?.[currentPracticeStep]?.titleNew || "L1";
   let apiLevel = `M${level}-${currentLevel}`;
+
+  if (level >= 4 && level <= 9) {
+    currentLevel = practiceSteps?.[currentPracticeStep]?.name;
+    apiLevel = `M${level}-${currentLevel}`;
+  }
 
   const callTelemetry = async () => {
     const sessionId = getLocalData("sessionId");

--- a/src/components/Practice/FluencyP5.jsx
+++ b/src/components/Practice/FluencyP5.jsx
@@ -533,8 +533,13 @@ const FluencyP5 = ({
     currentPracticeStep = progressDatas?.currentPracticeStep;
   }
 
-  const currentLevel = practiceSteps?.[currentPracticeStep]?.titleNew || "L1";
+  let currentLevel = practiceSteps?.[currentPracticeStep]?.titleNew || "L1";
   let apiLevel = `M${level}-${currentLevel}`;
+
+  if (level >= 4 && level <= 9) {
+    currentLevel = practiceSteps?.[currentPracticeStep]?.name;
+    apiLevel = `M${level}-${currentLevel}`;
+  }
 
   const callTelemetry = async () => {
     const sessionId = getLocalData("sessionId");

--- a/src/components/Practice/ParagraphFlow.jsx
+++ b/src/components/Practice/ParagraphFlow.jsx
@@ -577,8 +577,13 @@ const ParagraphFlow = ({
     currentPracticeStep = progressDatas?.currentPracticeStep;
   }
 
-  const currentLevel = practiceSteps?.[currentPracticeStep]?.titleNew || "L1";
+  let currentLevel = practiceSteps?.[currentPracticeStep]?.titleNew || "L1";
   let apiLevel = `M${level}-${currentLevel}`;
+
+  if (level >= 4 && level <= 9) {
+    currentLevel = practiceSteps?.[currentPracticeStep]?.name;
+    apiLevel = `M${level}-${currentLevel}`;
+  }
 
   const callTelemetry = async () => {
     const sessionId = getLocalData("sessionId");


### PR DESCRIPTION
Ex :M4-L2 but there is no level as L2 in m4.It should be P2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved practice level tracking and handling for levels 4–9 across multiple practice modules to ensure accurate level mapping and telemetry recording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->