### PR TITLE
Prevent Alphabet Chart instruction from triggering on F1-P1

### DIFF
--- a/src/components/Assesment/Assesment.jsx
+++ b/src/components/Assesment/Assesment.jsx
@@ -572,6 +572,8 @@ export const ProfileHeader = ({
       };
 
       setTimeout(() => {
+        // 🛡️ Guard: if alphabetDemoStop cleared the ref, don't play
+        if (chartAudioRef.current !== audio) return;
         audio.play().catch(() => {
           setShowChartPointer(false);
           setIsAudioPlaying(false);
@@ -580,38 +582,94 @@ export const ProfileHeader = ({
         });
       }, 500);
     };
-
-    const checkDemoCompletion = () => {
+    // 🛡️ Initial mount check: validate F1 flow + milestone before playing
+    // This blocks stale showAlphabetDemo from a previous session
+    const checkDemoOnMount = () => {
       const demoState = getLocalData("showAlphabetDemo");
+      if (demoState !== "true") return;
 
-      // 🔥 Only trigger when demo JUST completed
+      // Check if F1 flow is actually active
+      let isF1Active = false;
+      try {
+        const msStr = getLocalData("getMilestone");
+        if (msStr) {
+          const msData = JSON.parse(msStr);
+          isF1Active =
+            msData?.data?.milestone_level === "B" &&
+            msData?.data?.sub_milestone_level === "F1";
+        }
+      } catch (e) {
+        // ignore parse errors
+      }
+
+      if (isF1Active) {
+        // 🎯 Only auto-play for IMMEDIATE milestones (L1=index 0)
+        // Deferred milestones (A1=6, A2=13, A3=20) should ONLY play
+        // when user clicks "Start Game" → alphabetDemoTriggerRequest event
+        const immediateOnlyMilestones = [0];
+        const rawIndex = getLocalData("f1FlowIndex");
+        const currentF1Index = rawIndex !== null ? Number(rawIndex) : -1;
+
+        // 🔒 Also check if this milestone was already played (prevents replay on re-login)
+        let playedIndices = [];
+        try {
+          const playedRaw = getLocalData("playedAlphabetDemoIndices");
+          playedIndices = playedRaw ? JSON.parse(playedRaw) : [];
+        } catch (e) {
+          playedIndices = [];
+        }
+
+        if (
+          immediateOnlyMilestones.includes(currentF1Index) &&
+          !playedIndices.includes(currentF1Index)
+        ) {
+          playChartAudio();
+          return;
+        }
+      }
+
+      // Not F1 flow or not at an allowed milestone → clear stale flag
+      setLocalData("showAlphabetDemo", "false");
+    };
+
+    // 🎬 Event-based trigger: Practice.jsx already validated the milestone
+    // before dispatching alphabetDemoComplete, so just play
+    const handleDemoEvent = () => {
+      const demoState = getLocalData("showAlphabetDemo");
       if (demoState === "true") {
         playChartAudio();
       }
     };
 
-    // Initial check
-    checkDemoCompletion();
+    // Initial check (validated)
+    checkDemoOnMount();
 
     const handleStorageChange = (e) => {
       if (e.key === "showAlphabetDemo" && e.newValue === "true") {
-        checkDemoCompletion();
+        handleDemoEvent();
       }
     };
 
-    const handleCustomStorageChange = () => {
-      checkDemoCompletion();
-    };
-
     window.addEventListener("storage", handleStorageChange);
-    window.addEventListener("alphabetDemoComplete", handleCustomStorageChange);
+    window.addEventListener("alphabetDemoComplete", handleDemoEvent);
+
+    // 🔇 Listen for stop signal from Practice.jsx (non-milestone cleanup)
+    const handleDemoStop = () => {
+      if (chartAudioRef.current) {
+        chartAudioRef.current.pause();
+        chartAudioRef.current.currentTime = 0;
+        chartAudioRef.current = null;
+      }
+      setShowChartPointer(false);
+      setIsAudioPlaying(false);
+      setLocalData("showAlphabetDemo", "false");
+    };
+    window.addEventListener("alphabetDemoStop", handleDemoStop);
 
     return () => {
       window.removeEventListener("storage", handleStorageChange);
-      window.removeEventListener(
-        "alphabetDemoComplete",
-        handleCustomStorageChange
-      );
+      window.removeEventListener("alphabetDemoComplete", handleDemoEvent);
+      window.removeEventListener("alphabetDemoStop", handleDemoStop);
 
       if (chartAudioRef.current) {
         chartAudioRef.current.pause();

--- a/src/components/Layouts.jsx/MainLayout.jsx
+++ b/src/components/Layouts.jsx/MainLayout.jsx
@@ -2118,10 +2118,16 @@ const MainLayout = (props) => {
                         }
                         if (isShowCase && !startShowCase && !gameOverData) {
                           setStartShowCase(true);
-                          // 🎬 Trigger alphabet demo ONLY for F1 flow deferred milestones (A1=6, A2=13, A3=20)
-                          // Practice.jsx will also validate, but gate here to avoid unnecessary events
+                          // 🎬 Trigger alphabet demo ONLY for F1 flow deferred milestones (A-step indices)
+                          // Derive from F1_FLOW so it stays in sync with Practice.jsx
                           if (isF1FlowActive) {
-                            const deferredMilestones = [6, 13, 20];
+                            const deferredMilestones = F1_FLOW.reduce(
+                              (acc, step, idx) => {
+                                if (step.type === "A") acc.push(idx);
+                                return acc;
+                              },
+                              []
+                            );
                             const currentF1Index = Number(
                               getLocalData("f1FlowIndex") || -1
                             );

--- a/src/components/Layouts.jsx/MainLayout.jsx
+++ b/src/components/Layouts.jsx/MainLayout.jsx
@@ -519,9 +519,23 @@ const MainLayout = (props) => {
 
     const userDidNotWin = gameOverData.userWon !== true;
     const isValidLevel = [1, 2, 3].includes(LEVEL);
-    const isStepNine = props?.progressData?.currentPracticeStep === 9;
 
-    if (userDidNotWin && isValidLevel && isStepNine) {
+    // Determine if demo should trigger based on flow type:
+    // - F1 flow active: only trigger for L1 (index 0) — the only IMMEDIATE milestone
+    //   A1/A2/A3 are DEFERRED and only trigger from Start Game button click
+    // - Non-F1 flow (regular): trigger when user fails at S2 (step 9)
+    let shouldTrigger = false;
+    if (isF1FlowActive) {
+      const immediateMilestones = [0]; // Only L1
+      const currentF1Index = Number(getLocalData("f1FlowIndex") || -1);
+      shouldTrigger = immediateMilestones.includes(currentF1Index);
+    } else {
+      // Regular flow: S2 fail scenario (step 9)
+      const isStepNine = props?.progressData?.currentPracticeStep === 9;
+      shouldTrigger = isStepNine;
+    }
+
+    if (userDidNotWin && isValidLevel && shouldTrigger) {
       hasTriggeredDemoRef.current = true;
 
       setLocalData("showAlphabetDemo", "true");
@@ -529,7 +543,12 @@ const MainLayout = (props) => {
 
       window.dispatchEvent(new Event("alphabetDemoComplete"));
     }
-  }, [gameOverData, LEVEL, props?.progressData?.currentPracticeStep]);
+  }, [
+    gameOverData,
+    LEVEL,
+    props?.progressData?.currentPracticeStep,
+    isF1FlowActive,
+  ]);
 
   let currentPracticeStep = progressData?.currentPracticeStep;
   // For F1/F2/F3 flow, use the flow index instead of currentPracticeStep
@@ -2099,11 +2118,19 @@ const MainLayout = (props) => {
                         }
                         if (isShowCase && !startShowCase && !gameOverData) {
                           setStartShowCase(true);
-                          // 🎬 Trigger alphabet demo for F1 flow milestones (A1, A2, A3)
-                          // Practice.jsx will listen for this event and check if it's a valid milestone
-                          window.dispatchEvent(
-                            new Event("alphabetDemoTriggerRequest")
-                          );
+                          // 🎬 Trigger alphabet demo ONLY for F1 flow deferred milestones (A1=6, A2=13, A3=20)
+                          // Practice.jsx will also validate, but gate here to avoid unnecessary events
+                          if (isF1FlowActive) {
+                            const deferredMilestones = [6, 13, 20];
+                            const currentF1Index = Number(
+                              getLocalData("f1FlowIndex") || -1
+                            );
+                            if (deferredMilestones.includes(currentF1Index)) {
+                              window.dispatchEvent(
+                                new Event("alphabetDemoTriggerRequest")
+                              );
+                            }
+                          }
                         }
                         if (gameOverData) {
                           gameOverData.link

--- a/src/views/Practice/Practice.jsx
+++ b/src/views/Practice/Practice.jsx
@@ -4582,8 +4582,21 @@ const Practice = () => {
       return acc;
     }, []);
 
+    const milestoneIndices = [...immediateMilestones, ...deferredMilestones];
+
+    // 🛡️ Clear stale showAlphabetDemo if current index is NOT a milestone
+    // This prevents the chart audio from playing after re-login at a non-milestone step (e.g., P1)
+    if (!milestoneIndices.includes(f1FlowIndexState)) {
+      const staleDemo = getLocalData("showAlphabetDemo");
+      if (staleDemo === "true") {
+        setLocalData("showAlphabetDemo", "false");
+        // 🔇 Tell Assesment.jsx to stop any playing chart audio
+        window.dispatchEvent(new Event("alphabetDemoStop"));
+      }
+      return; // Not at a milestone, no need to set up triggers
+    }
+
     const handleTrigger = (index) => {
-      const milestoneIndices = [...immediateMilestones, ...deferredMilestones];
       if (isF1FlowActive && milestoneIndices.includes(index)) {
         const playedIndicesRaw = getLocalData("playedAlphabetDemoIndices");
         let playedIndices = [];
@@ -4609,12 +4622,14 @@ const Practice = () => {
       }
     };
 
-    // 1. Immediate trigger for non-showcase milestones
+    // 1. Immediate trigger for L1 milestone (index 0)
+    // Trigger directly when this useEffect runs, no need for event
     if (immediateMilestones.includes(f1FlowIndexState)) {
       handleTrigger(f1FlowIndexState);
     }
 
     // 2. Listener for deferred trigger (e.g., from MainLayout "Start Game" button)
+    // Only for showcase milestones A1, A2, A3
     const handleTriggerRequest = () => {
       if (deferredMilestones.includes(f1FlowIndexState)) {
         handleTrigger(f1FlowIndexState);


### PR DESCRIPTION
- Added a condition to ensure the Alphabet Chart instruction triggers only during F1-L1 and A1,A2,A3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a graceful stop control to halt alphabet demo audio and UI pointers on demand.

* **Bug Fixes**
  * Demo audio now only auto-plays at intended milestone steps and only for immediate milestones in the F1 flow.
  * Prevented stale/demo replay after stop signals or re-login by clearing stale flags and tightening trigger conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->