### PR TITLE
Issue #0000 fix: apply discovery after set3 only

### DIFF
--- a/src/components/DiscoverSentance/DiscoverSentance.jsx
+++ b/src/components/DiscoverSentance/DiscoverSentance.jsx
@@ -274,12 +274,14 @@ const SpeakSentenceComponent = () => {
         setCurrentQuestion(currentQuestion + 1);
       } else if (currentQuestion === questions.length - 1) {
         const sub_session_id = getLocalData("sub_session_id");
+        const isThirdDiscoverySet = discoveryHistoryRef.current.length === 2;
         const getSetResultRes = await fetchGetSetResult(
           sub_session_id,
           currentContentType,
           currentCollectionId,
           totalSyllableCount,
-          currentSetTag
+          currentSetTag,
+          isThirdDiscoverySet
         );
 
         // Call engagement predictor after getsetresult

--- a/src/components/Practice/AserFlow.jsx
+++ b/src/components/Practice/AserFlow.jsx
@@ -353,7 +353,8 @@ const AserFlow = ({
         currentContentType,
         currentCollectionId,
         totalSyllableCount,
-        discoveryCharActive ? "set1" : undefined
+        discoveryCharActive ? "set1" : undefined,
+        discoveryCharActive ? true : undefined
       );
       const { data } = getSetResultRes;
       getSetResultData = data;

--- a/src/services/learnerAi/learnerAiService.js
+++ b/src/services/learnerAi/learnerAiService.js
@@ -95,7 +95,8 @@ export const fetchGetSetResult = async (
   currentContentType,
   currentCollectionId,
   totalSyllableCount,
-  setTag
+  setTag,
+  applyDiscoveryMilestone
 ) => {
   const session_id = getLocalData("sessionId");
   const lang = getLocalData("lang");
@@ -112,6 +113,9 @@ export const fetchGetSetResult = async (
     };
     if (setTag) {
       body.setTag = setTag;
+    }
+    if (applyDiscoveryMilestone === true) {
+      body.applyDiscoveryMilestone = true;
     }
     const response = await axios.post(
       `${API_LEARNER_AI_APP_HOST}/${config.URLS.GET_SET_RESULT}`,


### PR DESCRIPTION
Issue #0000 fix: apply discovery after set3 only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced discovery milestone application logic to better track learning progress across discovery sets.
  * Improved handling of discovery feature state during lesson completion workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->