### PR TITLE
Tassk #0000 fix : M2 contentlimit set to 10 for P4

### DIFF
--- a/src/data/levelContent.js
+++ b/src/data/levelContent.js
@@ -4559,6 +4559,7 @@ export const levelGetContent = {
         criteria: "word",
         template: "simple",
         tags: "CEFR_M2_P4",
+        contentCount: 10,
         multilingual: false,
       },
       {


### PR DESCRIPTION
Tassk #0000 fix : M2 contentlimit set to 10 for P4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * Refined level content configuration to optimize content delivery and ensure consistency across learning modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->