### PR TITLE
Issue #0000 fix: show loader for getSetResult

### DIFF
--- a/src/services/learnerAi/getSetResultLoading.js
+++ b/src/services/learnerAi/getSetResultLoading.js
@@ -1,4 +1,4 @@
-/** Ref-counted loading for fetchGetSetResult (overlapping calls keep overlay until all finish). */
+/** Ref-counted loading for getSetResult API calls via fetchGetSetResult and getSetResultPractice (overlapping calls keep overlay until all finish). */
 let refCount = 0;
 const listeners = new Set();
 

--- a/src/services/learnerAi/learnerAiService.js
+++ b/src/services/learnerAi/learnerAiService.js
@@ -152,9 +152,10 @@ export const getSetResultPractice = async ({
   totalSyllableCount,
   mechanism,
 }) => {
-  try {
-    const maxLevel = getLocalData("max_level");
+  const maxLevel = getLocalData("max_level");
 
+  beginGetSetResultRequest();
+  try {
     const response = await axios.post(
       `${API_LEARNER_AI_APP_HOST}/${config.URLS.GET_SET_RESULT}`,
       {
@@ -172,6 +173,8 @@ export const getSetResultPractice = async ({
   } catch (error) {
     console.error("Error fetching set result:", error);
     throw error; // Rethrow the error to handle it in the calling function
+  } finally {
+    endGetSetResultRequest();
   }
 };
 


### PR DESCRIPTION
Issue #0000 fix: show loader for getSetResult

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced loading overlay reliability for GetSet Result operations to ensure the loading indicator properly displays and clears during all API calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->