### PR TITLE
Hotfix: Audio Diagnostic page not displaying in AXL app iframe login flow

### DIFF
--- a/src/views/AppContent/AppContent.jsx
+++ b/src/views/AppContent/AppContent.jsx
@@ -1,7 +1,9 @@
-import React, { useEffect, Fragment, Suspense } from "react";
+import React, { useEffect, Fragment, Suspense, useState } from "react";
 import { Routes, Route, useNavigate } from "react-router-dom";
 import CustomizedSnackbars from "../../views/Snackbar/CustomSnackbar";
 import LoadingFallback from "../../components/LoadingFallback";
+import { AudioDiagnosticModal } from "../../components/AudioDiagnostic";
+import { getLocalData, setLocalData } from "../../utils/constants";
 
 const PrivateRoute = (props) => {
   const TOKEN = localStorage.getItem("apiToken");
@@ -21,24 +23,40 @@ const PrivateRoute = (props) => {
 };
 
 const AppContent = ({ routes }) => {
+  const [showDiagnostic, setShowDiagnostic] = useState(
+    process.env.REACT_APP_IS_APP_IFRAME === "true" &&
+      !!localStorage.getItem("apiToken") &&
+      !getLocalData("audioDiagnosticShown")
+  );
+
   return (
     <Fragment>
       <CustomizedSnackbars />
-      <Suspense fallback={<LoadingFallback />}>
-        <Routes>
-          {routes.map((route) => (
-            <Route
-              key={route.id}
-              path={route.path}
-              element={
-                <PrivateRoute requiresAuth={route.requiresAuth}>
-                  <route.component />
-                </PrivateRoute>
-              }
-            />
-          ))}
-        </Routes>
-      </Suspense>
+      {showDiagnostic ? (
+        <AudioDiagnosticModal
+          show={showDiagnostic}
+          onClose={() => {
+            setShowDiagnostic(false);
+            setLocalData("audioDiagnosticShown", "true");
+          }}
+        />
+      ) : (
+        <Suspense fallback={<LoadingFallback />}>
+          <Routes>
+            {routes.map((route) => (
+              <Route
+                key={route.id}
+                path={route.path}
+                element={
+                  <PrivateRoute requiresAuth={route.requiresAuth}>
+                    <route.component />
+                  </PrivateRoute>
+                }
+              />
+            ))}
+          </Routes>
+        </Suspense>
+      )}
     </Fragment>
   );
 };

--- a/src/views/LoginPage/LoginPage.jsx
+++ b/src/views/LoginPage/LoginPage.jsx
@@ -554,6 +554,9 @@ const LoginPage = () => {
         show={showAudioDiagnostic}
         onClose={() => {
           setShowAudioDiagnostic(false);
+          if (process.env.REACT_APP_IS_APP_IFRAME === "true") {
+            setLocalData("audioDiagnosticShown", "true");
+          }
           handleWordClick();
           navigate("/discover-start");
         }}


### PR DESCRIPTION
## Summary

Ported the Audio Diagnostic fix from **all-3.0.4-hotfix (#847)** to **all-3.0.5** with an improved approach.

The diagnostic page (panda screen — *"Hi! Listen to the audio and repeat it!"*) was not displaying in the AXL app parent login flow. This fix ensures it appears consistently in both the direct ALL portal login and AXL app iframe login flows.

---

## Root Cause

In the AXL app parent login flow:

* `ts-axl-app` authenticates the user and sets `apiToken` directly in `localStorage` before the ALL app iframe loads
* When the ALL app initializes inside the iframe, `apiToken` already exists
* The wildcard route (`*`) resolves to `DiscoverStart`, skipping `LoginPage` entirely
* `AudioDiagnosticModal` was only triggered inside `LoginPage`, so it was never shown in the iframe flow

---

## What Changed vs Hotfix (#847)

* The previous hotfix placed the fix in `DiscoverStartPage`
* This update improves the approach by moving the logic to `AppContent`, which:

  * Is the root of all authenticated routes
  * Mounts once regardless of the route the user lands on

### Additional Bug Fix

* The **LanguageModal** (*"Choose your help language"*) was appearing on top of the Audio Diagnostic modal
* This happened because:

  * `DiscoverStart → Assesment` was mounting in the background
  * It auto-triggered the language modal
* **Fix:** Blocked route rendering while the diagnostic is active

---

## Files Changed

### `src/views/AppContent/AppContent.jsx` — Main Fix

* Added `AudioDiagnosticModal`, triggered on mount when:

  * `REACT_APP_IS_APP_IFRAME === "true"`
  * `apiToken` exists in `localStorage`
  * `audioDiagnosticShown` flag is not set

* Used conditional (ternary) rendering:

  * Routes are blocked while the diagnostic is showing
  * Prevents background components (`Assesment`, `LanguageModal`) from mounting and interfering

---

### `src/views/LoginPage/LoginPage.jsx` — Prevent Double Trigger

* Sets `audioDiagnosticShown` flag in `AudioDiagnosticModal` `onClose`, guarded by:

  ```js
  REACT_APP_IS_APP_IFRAME === "true"
  ```

* Prevents the diagnostic from reappearing on page refresh after direct ALL portal login

-

## What Was NOT Changed

* No changes to `AudioDiagnosticModal` component
* No changes to `App.js`, `Assesment.jsx`, or routing configuration
* No changes to authentication flow or token handling
* No UI, layout, or styling changes

---

## Testing

* [x] AXL app login → ALL iframe loads → Audio Diagnostic displays correctly
* [x] Language modal does **not** appear on top of the Audio Diagnostic
* [x] Direct ALL portal login → Diagnostic appears only once (no duplication)
* [x] Skip diagnostic → `audioDiagnosticShown` is set → Not shown again
* [x] Complete diagnostic → `audioDiagnosticShown` is set → Not shown again
* [x] Logout → `localStorage.clear()` removes flag → Diagnostic shown on next login
* [x] No regression observed in existing login flows

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an audio diagnostic modal that displays in specific application scenarios.
  * Users can dismiss the modal; dismissal status is saved and will not reappear in future sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->