### PR TITLE
Fix Missing Set 2 Completion Popup in Discovery Flow

### DIFF
--- a/src/components/DiscoverSentance/DiscoverSentance.jsx
+++ b/src/components/DiscoverSentance/DiscoverSentance.jsx
@@ -1,3 +1,4 @@
+/* global globalThis */
 import { useEffect, useState, useRef } from "react";
 import CircularProgress from "@mui/material/CircularProgress";
 import Box from "@mui/material/Box";
@@ -80,7 +81,7 @@ const SpeakSentenceComponent = () => {
     let audio = new Audio(levelCompleteAudioSrc);
     audio.play();
     callConfetti();
-    window.telemetry?.syncEvents?.();
+    globalThis.telemetry?.syncEvents?.();
   };
 
   const dispatchCompletionDialog = (setNumber, resolve) => {

--- a/src/components/DiscoverSentance/DiscoverSentance.jsx
+++ b/src/components/DiscoverSentance/DiscoverSentance.jsx
@@ -83,24 +83,24 @@ const SpeakSentenceComponent = () => {
     window.telemetry?.syncEvents && window.telemetry.syncEvents();
   };
 
-  useEffect(() => {
-    if (questions?.length) setAssesmentcount(assesmentCount + 1);
-  }, [questions]);
-
-  useEffect(() => {
-    if (questions?.length && !initialAssesment && currentQuestion === 0) {
+  const showCompletionPopup = (setNumber) =>
+    new Promise((resolve) => {
       setDisableScreen(true);
       callConfettiAndPlay();
       setTimeout(() => {
-        // alert();
         setOpenMessageDialog({
-          message:
-            "You have successfully completed assessment " + assesmentCount,
+          message: "You have successfully completed assessment " + setNumber,
+          __onClose: () => {
+            setDisableScreen(false);
+            resolve();
+          },
         });
-        // setDisableScreen(false);
       }, 1200);
-    }
-  }, [currentQuestion]);
+    });
+
+  useEffect(() => {
+    if (questions?.length) setAssesmentcount(assesmentCount + 1);
+  }, [questions]);
 
   useEffect(() => {
     if (!localStorage.getItem("contentSessionId")) {
@@ -364,6 +364,9 @@ const SpeakSentenceComponent = () => {
           language: lang,
           milestoneLevel: "m0",
         });
+        if (newHistory.length < 3) {
+          await showCompletionPopup(newHistory.length);
+        }
         await loadDiscoveryNextSet(newHistory, assessmentResponse);
       }
     } catch (error) {
@@ -386,8 +389,8 @@ const SpeakSentenceComponent = () => {
           try {
             charRes = JSON.parse(charRaw);
           } catch {
-            sessionStorage.removeItem(DISCOVERY_SET_FLOW_STORAGE.CHAR_RESULT);
             const resAssessment = await fetchAssessmentData(lang);
+            sessionStorage.removeItem(DISCOVERY_SET_FLOW_STORAGE.CHAR_RESULT);
             if (cancelled) return;
             await initDiscoveryFromSet4(resAssessment);
             return;
@@ -395,8 +398,8 @@ const SpeakSentenceComponent = () => {
 
           let mergedHistory;
           try {
-            sessionStorage.removeItem(DISCOVERY_SET_FLOW_STORAGE.CHAR_RESULT);
             const resAssessment = await fetchAssessmentData(lang);
+            sessionStorage.removeItem(DISCOVERY_SET_FLOW_STORAGE.CHAR_RESULT);
             if (cancelled) return;
             const stateRaw = sessionStorage.getItem(
               DISCOVERY_SET_FLOW_STORAGE.STATE
@@ -432,6 +435,12 @@ const SpeakSentenceComponent = () => {
                 pendingCharSetTag: null,
               })
             );
+            setInitialAssesment(false);
+            setQuestionsReady(true);
+            if (mergedHistory.length < 3) {
+              await showCompletionPopup(mergedHistory.length);
+            }
+            if (cancelled) return;
             await loadDiscoveryNextSet(mergedHistory, resAssessment);
           } catch (e) {
             console.error("Discovery char resume error:", e);
@@ -469,8 +478,12 @@ const SpeakSentenceComponent = () => {
   useEffect(() => {
     localStorage.setItem("mechanism_id", "");
 
-    // Always show demo when entering discovery page
-    setShowDemo(true);
+    const isCharResume = !!sessionStorage.getItem(
+      DISCOVERY_SET_FLOW_STORAGE.CHAR_RESULT
+    );
+    if (!isCharResume) {
+      setShowDemo(true);
+    }
   }, []);
 
   const handleDemoComplete = () => {
@@ -577,8 +590,10 @@ const SpeakSentenceComponent = () => {
         <MessageDialog
           message={openMessageDialog.message}
           closeDialog={() => {
+            const cb = openMessageDialog && openMessageDialog.__onClose;
             setOpenMessageDialog("");
             setDisableScreen(false);
+            if (cb) cb();
           }}
           isError={openMessageDialog.isError}
           dontShowHeader={openMessageDialog.dontShowHeader}

--- a/src/components/DiscoverSentance/DiscoverSentance.jsx
+++ b/src/components/DiscoverSentance/DiscoverSentance.jsx
@@ -80,22 +80,25 @@ const SpeakSentenceComponent = () => {
     let audio = new Audio(levelCompleteAudioSrc);
     audio.play();
     callConfetti();
-    window.telemetry?.syncEvents && window.telemetry.syncEvents();
+    window.telemetry?.syncEvents?.();
+  };
+
+  const dispatchCompletionDialog = (setNumber, resolve) => {
+    const handleDialogClose = () => {
+      setDisableScreen(false);
+      resolve();
+    };
+    setOpenMessageDialog({
+      message: "You have successfully completed assessment " + setNumber,
+      __onClose: handleDialogClose,
+    });
   };
 
   const showCompletionPopup = (setNumber) =>
     new Promise((resolve) => {
       setDisableScreen(true);
       callConfettiAndPlay();
-      setTimeout(() => {
-        setOpenMessageDialog({
-          message: "You have successfully completed assessment " + setNumber,
-          __onClose: () => {
-            setDisableScreen(false);
-            resolve();
-          },
-        });
-      }, 1200);
+      setTimeout(() => dispatchCompletionDialog(setNumber, resolve), 1200);
     });
 
   useEffect(() => {
@@ -590,7 +593,7 @@ const SpeakSentenceComponent = () => {
         <MessageDialog
           message={openMessageDialog.message}
           closeDialog={() => {
-            const cb = openMessageDialog && openMessageDialog.__onClose;
+            const cb = openMessageDialog?.__onClose;
             setOpenMessageDialog("");
             setDisableScreen(false);
             if (cb) cb();


### PR DESCRIPTION
# Summary

Fixed the missing "You have completed Set 2" popup in the Discovery stage.

After completing Set 1, the popup "You have successfully completed assessment 1" appeared correctly. However, after completing Set 2, the popup was missing in several adaptive paths (especially when Set 2 was a letter-hunt / Char set). This fix makes the Set 2 popup appear reliably in all paths.


---

# Root Cause

The popup was driven by a fragile `useEffect` that fired only when `currentQuestion` reset to `0`.

This trigger failed in the letter-hunt path for four reasons:

## 1. Component Remount Race

When Set 2 was a Char set, the user was navigated to `/letter-hunt`.

On return:

- The Discover page mounted fresh
- `currentQuestion` was already `0`
- The `"reset to 0"` trigger never fired

---

## 2. Demo Screen Blocking the Popup

The demo preview (`DiscoverSentencePreview`) was re-shown on return from letter-hunt because the `CHAR_RESULT` flag (used to skip the demo) was deleted from `sessionStorage` before the demo-skip `useEffect` could read it.

The two effects ran in declaration order:

1. Startup effect synchronously removed `CHAR_RESULT`
2. Demo effect checked for the flag afterward
3. The demo screen render short-circuit hid the popup behind it

---

## 3. Stuck Loader on Return

`setQuestionsReady(true)` was missing from the char-resume branch.

Because of this:

- The loading spinner remained visible
- The next set loaded correctly internally
- UI stayed stuck on the loader


---

# What Changed

Replaced the brittle `useEffect`-based trigger with an explicit, awaitable:

```js
showCompletionPopup(setNumber)
```

helper invoked at the exact moment a set completes.

Popup execution is guarded with:

```js
history.length < 3
```

so it never fires after Set 3.

Fixed the demo-screen race by delaying:

```js
sessionStorage.removeItem(CHAR_RESULT)
```

until after the data fetch completes, allowing the demo-skip logic to read the flag correctly before it is cleared.

---

# Files Changed

## `src/components/DiscoverSentance/DiscoverSentance.jsx` — Main Fix

### Added

Added:

```js
showCompletionPopup(setNumber)
```

helper that wraps the popup in a Promise so it can be awaited until the user dismisses it.

---

### Removed

Removed the legacy:

```js
useEffect(() => {
  ...
}, [currentQuestion]);
```

dependency-based popup trigger.

This trigger was unreliable during remount and letter-hunt resume flows.

---

### Updated `handleNext`

After a set completes:

```js
await showCompletionPopup(newHistory.length);
```

is called.

Guarded with:

```js
if (newHistory.length < 3)
```

to suppress popup display after Set 3 because Tower flow handles that case.

---

### Updated Char Resume Branch (`/letter-hunt` return)

Added:

```js
setInitialAssesment(false);
setQuestionsReady(true);
```

Fixes:

- Loader remaining indefinitely
- Resume-state initialization issues

Also added:

```js
await showCompletionPopup(mergedHistory.length);
```

under the same `< 3` guard.

---

### Updated Demo `useEffect`

Added an:

```js
isCharResume
```

check so the demo preview is skipped when the user returns from `/letter-hunt`.

---

### Updated Session Storage Timing

Moved:

```js
sessionStorage.removeItem(CHAR_RESULT);
```

to after:

```js
await fetchAssessmentData(lang);
```

so the demo-skip check can read the flag before it is cleared.

---

### Updated `MessageDialog`

`closeDialog` now invokes an optional:

```js
__onClose
```

callback.

This allows the awaiting Promise in `showCompletionPopup` to resolve after user dismissal.

Existing error popups (without `__onClose`) remain unaffected.

---

### Popup Numbering Fix

Popup messages now use:

```js
newHistory.length
```

instead of the buggy:

```js
assesmentCount
```

Result:

- Set 1 → `"completed 1"`
- Set 2 → `"completed 2"`
- Never shows `"completed 3"`

---

# What Was NOT Changed

- No changes to `src/utils/discoverSetFlow.js` (adaptive path resolution logic)
- No changes to `AserFlow.jsx` / `LetterHuntMechanics.jsx` (letter-hunt flow)
- No changes to the Tower flow or its completion message
- No changes to API calls:
  - `fetchGetSetResult`
  - `addLesson`
  - `addPointer`
  - `createLearnerProgress`
  - `callEngagementPredictor`
- No changes to telemetry, interaction tracking, or sub-session logic
- No changes to `DiscoverSentencePreview` (demo) or `DiscoverEnd` terminal page
- No changes to authentication or routing
- No UI, layout, or styling changes

# Testing
- Pass-Pass 
  - Popup `"You have successfully completed assessment 1"` appears after Set 1
  - Popup `"You have successfully completed assessment 2"` appears after Set 2
  - No popup after Set 3
  - Direct navigation to `/towre-flow`
  - Tower-flow success message appears after Tower completion

- Fail-Fail  — letter-hunt sets
  - Popup `"completed 1"` appears after Set 1
  - Navigates to `/letter-hunt` for Set 2
  - On return, demo preview does not re-appear
  - Popup `"completed 2"` appears after Set 2 (on char-resume)
  - Navigates to `/letter-hunt` for Set 3
  - On return, no popup is displayed
  - Direct navigation to `/discover-end`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an async completion popup flow with confetti and audio when users reach progression milestones.

* **Bug Fixes**
  * Ensured the completion popup appears at the correct progression points and blocks/resumes UI appropriately.
  * Fixed demo visibility so the demo only shows under the intended conditions.
  * Improved message dialog close handling to reliably restore state and re-enable the screen.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sunbird-ALL/all-learner-ai-app/pull/866?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->