### PR TITLE
FIX ALL-232 : In bingo card order selection issue fix

### DIFF
--- a/src/components/Practice/BingoCard.jsx
+++ b/src/components/Practice/BingoCard.jsx
@@ -1044,7 +1044,7 @@ const BingoCard = ({
 
         const isCorrectPair =
           newSelected.length === requiredParts.length &&
-          requiredParts.every((part) => newSelected.includes(part));
+          requiredParts.every((part, index) => newSelected[index] === part);
 
         if (isCorrectPair) {
           setMatchedPair({ fullWord: currentWord, parts: requiredParts });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bingo card pair matching validation. Selected items must now match both content and sequence order to successfully validate a pair match.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sunbird-ALL/all-learner-ai-app/pull/872?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->