### PR TITLE
ALL-264  MCQ mechanics , MCQ showcase M4 S1 , M5 S1

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+  "editor.formatOnSave": false,
+  "editor.trimTrailingWhitespace": true,
+  "files.trimFinalNewlines": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll": "never",
+    "source.fixAll.eslint": "never"
+  }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,0 @@
-{
-  "editor.formatOnSave": false,
-  "editor.trimTrailingWhitespace": true,
-  "files.trimFinalNewlines": true,
-  "editor.codeActionsOnSave": {
-    "source.fixAll": "never",
-    "source.fixAll.eslint": "never"
-  }
-}

--- a/src/components/Layout/MainLayout.jsx
+++ b/src/components/Layout/MainLayout.jsx
@@ -1175,6 +1175,7 @@ const MainLayout = (props) => {
                           ...Array(Math.max(0, redLivesToShow) || 0).keys(),
                         ]?.map((elem) => (
                           <Diamond
+                            key={`red-live-${elem}`}
                             height={isMobile ? "25px" : "50px"}
                             width={isMobile ? "25px" : "50px"}
                             style={{ flexShrink: 0 }}
@@ -1185,6 +1186,7 @@ const MainLayout = (props) => {
                           ...Array(Math.max(0, blackLivesToShow) || 0).keys(),
                         ]?.map((elem) => (
                           <HeartBlack
+                            key={`black-live-${elem}`}
                             height={isMobile ? "25px" : "50px"}
                             width={isMobile ? "25px" : "50px"}
                             style={{ flexShrink: 0 }}

--- a/src/components/Layout/MainLayout.jsx
+++ b/src/components/Layout/MainLayout.jsx
@@ -430,6 +430,7 @@ const MainLayout = (props) => {
     isCorrect,
     vocabCount,
     wordCount,
+    pageName,
   } = props;
 
   const [shake, setShake] = useState(false);
@@ -1159,21 +1160,90 @@ const MainLayout = (props) => {
                   startShowCase && (
                     <Box
                       position={"absolute"}
-                      top={20}
-                      left={20}
+                      top={
+                        isMobile &&
+                        (pageName === "m5" || pageName === "wordsorimage")
+                          ? 10
+                          : 20
+                      }
+                      left={
+                        isMobile &&
+                        (pageName === "m5" || pageName === "wordsorimage")
+                          ? "initial"
+                          : 20
+                      }
+                      right={
+                        isMobile &&
+                        (pageName === "m5" || pageName === "wordsorimage")
+                          ? 10
+                          : "initial"
+                      }
                       justifyContent={"center"}
+                      sx={{
+                        display:
+                          isMobile &&
+                          (pageName === "m5" || pageName === "wordsorimage")
+                            ? "flex"
+                            : "block",
+                        flexDirection:
+                          isMobile &&
+                          (pageName === "m5" || pageName === "wordsorimage")
+                            ? "column"
+                            : "initial",
+                        alignItems:
+                          isMobile &&
+                          (pageName === "m5" || pageName === "wordsorimage")
+                            ? "flex-end"
+                            : "initial",
+                      }}
                     >
-                      <Box display={"flex"}>
+                      <Box
+                        display={"flex"}
+                        gap={
+                          isMobile &&
+                          (pageName === "m5" || pageName === "wordsorimage")
+                            ? "3px"
+                            : "5px"
+                        }
+                      >
                         {[
                           ...Array(Math.max(0, redLivesToShow) || 0).keys(),
                         ]?.map((elem) => (
-                          <Diamond />
+                          <Diamond
+                            height={
+                              isMobile &&
+                              (pageName === "m5" || pageName === "wordsorimage")
+                                ? "25px"
+                                : "50px"
+                            }
+                            width={
+                              isMobile &&
+                              (pageName === "m5" || pageName === "wordsorimage")
+                                ? "25px"
+                                : "50px"
+                            }
+                            style={{ flexShrink: 0 }}
+                          />
                         ))}
 
                         {[
                           ...Array(Math.max(0, blackLivesToShow) || 0).keys(),
                         ]?.map((elem) => (
-                          <HeartBlack />
+                          <HeartBlack
+                            height={
+                              isMobile &&
+                              (pageName === "m5" || pageName === "wordsorimage")
+                                ? "25px"
+                                : "50px"
+                            }
+                            width={
+                              isMobile &&
+                              (pageName === "m5" || pageName === "wordsorimage")
+                                ? "25px"
+                                : "50px"
+                            }
+                            style={{ flexShrink: 0 }}
+                          />
                         ))}
                       </Box>
                       {redLivesToShow != null && (
@@ -1182,8 +1252,16 @@ const MainLayout = (props) => {
                             marginLeft: "5px",
                             color: "#000000",
                             fontWeight: 700,
-                            fontSize: "24px",
-                            lineHeight: "30px",
+                            fontSize:
+                              isMobile &&
+                              (pageName === "m5" || pageName === "wordsorimage")
+                                ? "14px"
+                                : "24px",
+                            lineHeight:
+                              isMobile &&
+                              (pageName === "m5" || pageName === "wordsorimage")
+                                ? "18px"
+                                : "30px",
                             fontFamily: "Quicksand",
                           }}
                         >

--- a/src/components/Layout/MainLayout.jsx
+++ b/src/components/Layout/MainLayout.jsx
@@ -1160,68 +1160,23 @@ const MainLayout = (props) => {
                   startShowCase && (
                     <Box
                       position={"absolute"}
-                      top={
-                        isMobile &&
-                        (pageName === "m5" || pageName === "wordsorimage")
-                          ? 10
-                          : 20
-                      }
-                      left={
-                        isMobile &&
-                        (pageName === "m5" || pageName === "wordsorimage")
-                          ? "initial"
-                          : 20
-                      }
-                      right={
-                        isMobile &&
-                        (pageName === "m5" || pageName === "wordsorimage")
-                          ? 10
-                          : "initial"
-                      }
+                      top={isMobile ? 10 : 20}
+                      left={isMobile ? "initial" : 20}
+                      right={isMobile ? 10 : "initial"}
                       justifyContent={"center"}
                       sx={{
-                        display:
-                          isMobile &&
-                          (pageName === "m5" || pageName === "wordsorimage")
-                            ? "flex"
-                            : "block",
-                        flexDirection:
-                          isMobile &&
-                          (pageName === "m5" || pageName === "wordsorimage")
-                            ? "column"
-                            : "initial",
-                        alignItems:
-                          isMobile &&
-                          (pageName === "m5" || pageName === "wordsorimage")
-                            ? "flex-end"
-                            : "initial",
+                        display: isMobile ? "flex" : "block",
+                        flexDirection: isMobile ? "column" : "initial",
+                        alignItems: isMobile ? "flex-end" : "initial",
                       }}
                     >
-                      <Box
-                        display={"flex"}
-                        gap={
-                          isMobile &&
-                          (pageName === "m5" || pageName === "wordsorimage")
-                            ? "3px"
-                            : "5px"
-                        }
-                      >
+                      <Box display={"flex"} gap={isMobile ? "3px" : "5px"}>
                         {[
                           ...Array(Math.max(0, redLivesToShow) || 0).keys(),
                         ]?.map((elem) => (
                           <Diamond
-                            height={
-                              isMobile &&
-                              (pageName === "m5" || pageName === "wordsorimage")
-                                ? "25px"
-                                : "50px"
-                            }
-                            width={
-                              isMobile &&
-                              (pageName === "m5" || pageName === "wordsorimage")
-                                ? "25px"
-                                : "50px"
-                            }
+                            height={isMobile ? "25px" : "50px"}
+                            width={isMobile ? "25px" : "50px"}
                             style={{ flexShrink: 0 }}
                           />
                         ))}
@@ -1230,18 +1185,8 @@ const MainLayout = (props) => {
                           ...Array(Math.max(0, blackLivesToShow) || 0).keys(),
                         ]?.map((elem) => (
                           <HeartBlack
-                            height={
-                              isMobile &&
-                              (pageName === "m5" || pageName === "wordsorimage")
-                                ? "25px"
-                                : "50px"
-                            }
-                            width={
-                              isMobile &&
-                              (pageName === "m5" || pageName === "wordsorimage")
-                                ? "25px"
-                                : "50px"
-                            }
+                            height={isMobile ? "25px" : "50px"}
+                            width={isMobile ? "25px" : "50px"}
                             style={{ flexShrink: 0 }}
                           />
                         ))}
@@ -1252,16 +1197,8 @@ const MainLayout = (props) => {
                             marginLeft: "5px",
                             color: "#000000",
                             fontWeight: 700,
-                            fontSize:
-                              isMobile &&
-                              (pageName === "m5" || pageName === "wordsorimage")
-                                ? "14px"
-                                : "24px",
-                            lineHeight:
-                              isMobile &&
-                              (pageName === "m5" || pageName === "wordsorimage")
-                                ? "18px"
-                                : "30px",
+                            fontSize: isMobile ? "14px" : "24px",
+                            lineHeight: isMobile ? "18px" : "30px",
                             fontFamily: "Quicksand",
                           }}
                         >

--- a/src/components/Layout/MainLayout.jsx
+++ b/src/components/Layout/MainLayout.jsx
@@ -430,7 +430,6 @@ const MainLayout = (props) => {
     isCorrect,
     vocabCount,
     wordCount,
-    pageName,
   } = props;
 
   const [shake, setShake] = useState(false);

--- a/src/components/Practice/Mechanics5.jsx
+++ b/src/components/Practice/Mechanics5.jsx
@@ -204,7 +204,7 @@ const Mechanics5 = ({
             alignItems: "center",
             textAlign: "center",
             color: "#333F61",
-            payddingTop: isMobile ? "10px" : isTablet ? "16vh" : "12vh",
+            paddingTop: isMobile ? "10px" : isTablet ? "16vh" : "12vh",
           }}
         >
           {header}

--- a/src/components/Practice/Mechanics5.jsx
+++ b/src/components/Practice/Mechanics5.jsx
@@ -231,7 +231,7 @@ const Mechanics5 = ({
             }}
           >
             {/* Image with full-width gradient overlay on top */}
-            {image?.split("/")?.[4] && (
+            {image && (
               <ZoomableImage
                 src={image}
                 alt="contentImage"

--- a/src/components/Practice/Mechanics5.jsx
+++ b/src/components/Practice/Mechanics5.jsx
@@ -178,198 +178,288 @@ const Mechanics5 = ({
         wordCount,
       }}
     >
-      <div
-        style={{
-          left: "calc(50% - 258px / 2)",
-          top: "calc(50% - 45px / 2 - 235.5px)",
-          fontFamily: getFontFamily(lang || "en"),
-          fontStyle: "normal",
-          fontWeight: 600,
-          fontSize: isMobile ? "22px" : "36px",
-          lineHeight: "45px",
-          alignItems: "center",
-          textAlign: "center",
-          color: "#333F61",
-          paddingTop: isMobile ? "17vh" : isTablet ? "16vh" : "12vh",
+      <Box
+        sx={{
+          display: { xs: "flex", sm: "block" },
+          flexDirection: { xs: "column", sm: "initial" },
+          height: { xs: "calc(100% - 55px)", sm: "auto" },
+          marginTop: { xs: "55px", sm: "0px" },
+          justifyContent: { xs: "flex-start", sm: "initial" },
+          alignItems: { xs: "center", sm: "initial" },
+          width: "100%",
+          overflowY: { xs: "auto", sm: "visible" },
+          paddingBottom: { xs: "90px", sm: "0px" },
+          boxSizing: "border-box",
         }}
       >
-        {header}
-      </div>
+        <div
+          style={{
+            left: "calc(50% - 258px / 2)",
+            top: "calc(50% - 45px / 2 - 235.5px)",
+            fontFamily: getFontFamily(lang || "en"),
+            fontStyle: "normal",
+            fontWeight: 600,
+            fontSize: isMobile ? "16px" : "36px",
+            lineHeight: isMobile ? "22px" : "45px",
+            alignItems: "center",
+            textAlign: "center",
+            color: "#333F61",
+            payddingTop: isMobile ? "10px" : isTablet ? "16vh" : "12vh",
+          }}
+        >
+          {header}
+        </div>
 
-      <Grid
-        container
-        sx={{ width: "70%", justifyContent: "center", mb: 2, mt: 8 }}
-      >
-        <Grid item xs={4} position="relative">
-          {/* Image with full-width gradient overlay on top */}
-          {image?.split("/")?.[4] && (
-            <ZoomableImage src={image} alt="contentImage" />
-          )}
-        </Grid>
-
-        <Grid item xs={8} paddingLeft={2}>
-          <Box
-            paddingBottom={3}
+        <Grid
+          container
+          sx={{
+            width: isMobile ? "100%" : "70%",
+            justifyContent: "center",
+            mb: 2,
+            mt: isMobile ? 1.5 : 8,
+          }}
+        >
+          <Grid
+            item
+            xs={12}
+            sm={4}
+            position="relative"
             sx={{
               display: "flex",
-              marginLeft: mechanism === "mechanic_4" ? "-10px" : "",
+              justifyContent: "center",
+              width: "100%",
             }}
           >
-            <audio
-              key={question_audio} // Key added to force remount when source changes
-              ref={questionAudioRef}
-              preload="metadata"
-              onPlaying={() => setPlayingIndex("question")}
-              onPause={() => setPlayingIndex(null)}
-            >
-              <source src={question_audio} type="audio/wav" />
-            </audio>
+            {/* Image with full-width gradient overlay on top */}
+            {image?.split("/")?.[4] && (
+              <ZoomableImage
+                src={image}
+                alt="contentImage"
+                imageStyle={
+                  isMobile
+                    ? {
+                        height: "140px",
+                        objectFit: "contain",
+                        borderRadius: "15px",
+                      }
+                    : {}
+                }
+              />
+            )}
+          </Grid>
+
+          <Grid
+            item
+            xs={12}
+            sm={8}
+            sx={{
+              paddingLeft: { xs: 0, sm: 2 },
+              mt: { xs: 2, sm: 0 },
+              width: "100%",
+            }}
+          >
             <Box
-              sx={{ cursor: "pointer" }}
-              onClick={() => togglePlayPause("question")}
-            >
-              {playingIndex === "question" ? (
-                <StopAudioButton size={35} color={"#1CB0F6"} />
-              ) : (
-                <PlayAudioButton size={35} color={"#1CB0F6"} />
-              )}
-            </Box>
-            <span
-              style={{
-                color: "#262649",
-                fontWeight: isMobile ? 600 : 800,
-                fontSize: isMobile ? "20px" : "26px",
-                fontFamily: getFontFamily(lang || "en"),
+              paddingBottom={isMobile ? 1 : 3}
+              sx={{
+                display: "flex",
+                marginLeft: mechanism === "mechanic_4" ? "-10px" : "",
               }}
             >
-              {parentWords}
-            </span>
-          </Box>
-          <Box
-            sx={{
-              ...(mechanism === "mechanic_4" && {
-                display: "flex",
-                justifyContent: "center",
-              }),
-              "@media (max-width:1100px)": {
-                gap: "40px",
-                flexWrap: "wrap",
-                justifyContent: "space-evenly",
-              },
-            }}
-          >
-            {options && options.length > 0 ? (
-              options.map((option, i) => (
-                <Box
-                  key={option.audio_url}
-                  mt={3}
-                  sx={{ display: "flex", alignItems: "center" }}
-                >
-                  <Radio
-                    checked={selectedOption === i}
-                    onChange={(e) => handleOptionChange(e, i)}
-                    value={i}
-                    name="options"
-                    color="primary"
-                  />
-                  <audio
-                    ref={audiosRef.current[i]}
-                    preload="metadata"
-                    onPlaying={() => setPlayingIndex(i)}
-                    onPause={() => setPlayingIndex(null)}
-                  >
-                    <source
-                      src={`${process.env.REACT_APP_AWS_S3_BUCKET_CONTENT_URL}/mechanics_audios/${option.audio_url}`}
-                      type="audio/wav"
-                    />
-                  </audio>
+              <audio
+                key={question_audio} // Key added to force remount when source changes
+                ref={questionAudioRef}
+                preload="metadata"
+                onPlaying={() => setPlayingIndex("question")}
+                onPause={() => setPlayingIndex(null)}
+              >
+                <source src={question_audio} type="audio/wav" />
+              </audio>
+              <Box
+                sx={{ cursor: "pointer" }}
+                onClick={() => togglePlayPause("question")}
+              >
+                {playingIndex === "question" ? (
+                  <StopAudioButton size={35} color={"#1CB0F6"} />
+                ) : (
+                  <PlayAudioButton size={35} color={"#1CB0F6"} />
+                )}
+              </Box>
+              <span
+                style={{
+                  color: "#262649",
+                  fontWeight: isMobile ? 600 : 800,
+                  fontSize: isMobile ? "15px" : "26px",
+                  fontFamily: getFontFamily(lang || "en"),
+                }}
+              >
+                {parentWords}
+              </span>
+            </Box>
+            <Box
+              sx={{
+                ...(mechanism === "mechanic_4" && {
+                  display: "flex",
+                  justifyContent: "center",
+                }),
+                "@media (max-width:1100px)": {
+                  gap: "40px",
+                  flexWrap: "wrap",
+                  justifyContent: "space-evenly",
+                },
+              }}
+            >
+              {options && options.length > 0 ? (
+                options.map((option, i) => (
                   <Box
-                    sx={{ cursor: "pointer", zIndex: 10, margin: "10px" }}
-                    onClick={() => togglePlayPause(i)}
+                    key={option.audio_url}
+                    mt={isMobile ? 0 : 3}
+                    sx={{ display: "flex", alignItems: "center" }}
                   >
-                    {playingIndex === i ? (
-                      <StopAudioButton size={35} color={"#1CB0F6"} />
-                    ) : (
-                      <PlayAudioButton size={35} color={"#1CB0F6"} />
-                    )}
-                  </Box>
-                  <Box sx={{ textAlign: "center" }}>
-                    {option.image_url && (
-                      <img
-                        src={`${process.env.REACT_APP_AWS_S3_BUCKET_CONTENT_URL}/mechanics_images/${option.image_url}`}
-                        style={{
-                          borderRadius: "20px",
-                          width: isMobile ? "110px" : "200px",
-                          height: isMobile ? "70px" : "150px",
-                        }}
-                        alt=""
-                      />
-                    )}
-
-                    <h1
-                      style={{
-                        color: "#262649",
-                        fontWeight: 600,
-                        fontSize: isMobile ? "17px" : "24px",
-                        fontFamily: getFontFamily(lang || "en"),
-                        marginLeft: isMobile ? "15px" : "10px",
-                      }}
+                    <Radio
+                      checked={selectedOption === i}
+                      onChange={(e) => handleOptionChange(e, i)}
+                      value={i}
+                      name="options"
+                      color="primary"
+                      sx={isMobile ? { padding: "4px" } : {}}
+                    />
+                    <audio
+                      ref={audiosRef.current[i]}
+                      preload="metadata"
+                      onPlaying={() => setPlayingIndex(i)}
+                      onPause={() => setPlayingIndex(null)}
                     >
-                      {option?.text || "Text is missing"}
-                    </h1>
-                  </Box>
-                </Box>
-              ))
-            ) : (
-              <div>No options available</div>
-            )}
-          </Box>
-        </Grid>
-      </Grid>
+                      <source
+                        src={`${process.env.REACT_APP_AWS_S3_BUCKET_CONTENT_URL}/mechanics_audios/${option.audio_url}`}
+                        type="audio/wav"
+                      />
+                    </audio>
+                    <Box
+                      sx={{
+                        cursor: "pointer",
+                        zIndex: 10,
+                        margin: isMobile ? "4px" : "10px",
+                      }}
+                      onClick={() => togglePlayPause(i)}
+                    >
+                      {playingIndex === i ? (
+                        <StopAudioButton size={35} color={"#1CB0F6"} />
+                      ) : (
+                        <PlayAudioButton size={35} color={"#1CB0F6"} />
+                      )}
+                    </Box>
+                    <Box sx={{ textAlign: "center" }}>
+                      {option.image_url && (
+                        <img
+                          src={`${process.env.REACT_APP_AWS_S3_BUCKET_CONTENT_URL}/mechanics_images/${option.image_url}`}
+                          style={{
+                            borderRadius: "20px",
+                            width: isMobile ? "110px" : "200px",
+                            height: isMobile ? "70px" : "150px",
+                          }}
+                          alt=""
+                        />
+                      )}
 
-      <Box paddingTop={1} sx={{ display: "flex", justifyContent: "center" }}>
-        <VoiceAnalyser
-          pageName={"m5"}
-          updateStoredData={updateStoredData}
-          setVoiceText={setVoiceText}
-          setRecordedAudio={setRecordedAudio}
-          setVoiceAnimate={setVoiceAnimate}
-          storyLine={storyLine}
-          dontShowListen={type === "image" || isDiscover}
-          isShowCase={isShowCase || isDiscover}
-          originalText={
-            options &&
-            options.length > 0 &&
-            options.find((option) => option.isAns === true).text
-              ? options.find((option) => option.isAns === true).text
-              : parentWords
-          }
-          enableNext={enableNext}
-          handleNext={handleNext}
-          selectedOption={options[selectedOption]}
-          correctness={correctness}
-          audioLink={audio ? audio : null}
-          {...{
-            contentId,
-            contentType,
-            currentLine: currentStep - 1,
-            playTeacherAudio,
-            callUpdateLearner,
-            isShowCase,
-            setEnableNext,
-            showOnlyListen: !options[selectedOption],
-            setOpenMessageDialog,
-            startShowCase,
-            setStartShowCase,
-            disableScreen,
-            livesData,
-            gameOverData,
-            loading,
-            setLivesData,
-            isNextButtonCalled,
-            setIsNextButtonCalled,
+                      <h1
+                        style={{
+                          color: "#262649",
+                          fontWeight: 600,
+                          fontSize: isMobile ? "14px" : "24px",
+                          fontFamily: getFontFamily(lang || "en"),
+                          marginLeft: isMobile ? "15px" : "10px",
+                          margin: isMobile ? "0px 0px 0px 2px" : "initial",
+                        }}
+                      >
+                        {option?.text || "Text is missing"}
+                      </h1>
+                    </Box>
+                  </Box>
+                ))
+              ) : (
+                <div>No options available</div>
+              )}
+            </Box>
+          </Grid>
+        </Grid>
+
+        <Box
+          paddingTop={1}
+          sx={{
+            display: "flex",
+            justifyContent: "center",
+            ...(isMobile && {
+              transform: "scale(0.7)",
+              transformOrigin: "top center",
+              "& > div > div > div": {
+                flexDirection: "row !important",
+                alignItems: "center",
+                gap: "10px",
+                "& > div": {
+                  marginBottom: "0px !important",
+                  marginTop: "0px !important",
+                },
+              },
+              "& .playing": {
+                width: "150px !important",
+                height: "30px !important",
+                padding: "0.2rem !important",
+                "& .playing__bar": {
+                  width: "1.5px !important",
+                },
+              },
+              "& .playing[style*='bottom']": {
+                bottom: "-22px !important",
+              },
+              "& .loader": {
+                marginTop: "20px !important",
+              },
+            }),
           }}
-        />
+        >
+          <VoiceAnalyser
+            pageName={"m5"}
+            updateStoredData={updateStoredData}
+            setVoiceText={setVoiceText}
+            setRecordedAudio={setRecordedAudio}
+            setVoiceAnimate={setVoiceAnimate}
+            storyLine={storyLine}
+            dontShowListen={type === "image" || isDiscover}
+            isShowCase={isShowCase || isDiscover}
+            originalText={
+              options &&
+              options.length > 0 &&
+              options.find((option) => option.isAns === true).text
+                ? options.find((option) => option.isAns === true).text
+                : parentWords
+            }
+            enableNext={enableNext}
+            handleNext={handleNext}
+            selectedOption={options[selectedOption]}
+            correctness={correctness}
+            audioLink={audio ? audio : null}
+            {...{
+              contentId,
+              contentType,
+              currentLine: currentStep - 1,
+              playTeacherAudio,
+              callUpdateLearner,
+              isShowCase,
+              setEnableNext,
+              showOnlyListen: !options[selectedOption],
+              setOpenMessageDialog,
+              startShowCase,
+              setStartShowCase,
+              disableScreen,
+              livesData,
+              gameOverData,
+              loading,
+              setLivesData,
+              isNextButtonCalled,
+              setIsNextButtonCalled,
+            }}
+          />
+        </Box>
       </Box>
     </MainLayout>
   );


### PR DESCRIPTION
**Prevented Diamond/Timer Overlap:** Relocated lives/diamonds indicator to the top-right corner on mobile (for both m5 and wordsorimage screens) and reduced icon size from 50px to 25px.

**Clipped Scrolling Content:** Added marginTop: "55px" and restricted scroll height to ensure scrolling text clips cleanly below the top widgets.

**Added Bottom Clearance:** Added paddingBottom: "90px" to the mobile container to prevent the bottom progress bar from covering action buttons when scrolled.

**Shrank Audio Wave Visualizer:** Reduced visualizer size (width to 150px, height to 30px, bar thickness to 1.5px) on mobile to fit compact screens.

**Reduced Loader Top Margin:** Reduced the green progress loader (.loader) top margin on mobile from 80px to 20px.
Centered UI Layout: Centered headers, questions, and audio options horizontally on mobile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced mobile responsiveness across the game UI with optimized layouts for different screen sizes.
  * Improved visual scaling and spacing of lives counter, question display, and answer options for clearer presentation.
  * Adaptive font sizing and positioning for better readability on mobile and desktop.

* **Refactor**
  * Layout rework for headers, media, and option areas to provide more consistent spacing and alignment.

* **Chores**
  * Editor settings adjusted (no user-facing behavior changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->