### PR TITLE
ALL-264 remove back button from 3-2-1 countdown phase in all game pre…

### DIFF
--- a/src/lib/axl-explorations/src/components/games/CombinedSentenceGamesPreview.tsx
+++ b/src/lib/axl-explorations/src/components/games/CombinedSentenceGamesPreview.tsx
@@ -912,17 +912,6 @@ export function CombinedSentenceGamesPreview({
     return (
       <div className="h-screen bg-gradient-cool p-2 sm:p-3 md:p-4 overflow-hidden flex flex-col">
         <div className="max-w-7xl mx-auto w-full flex-1 flex flex-col min-h-0 overflow-hidden">
-          {!hideHeader && (
-            <div className="flex items-center justify-between mb-3 flex-shrink-0">
-              <Button
-                onClick={handleBack}
-                className="bg-white/20 backdrop-blur-sm text-white hover:bg-white/30 border border-white/20 text-sm px-3 py-2"
-              >
-                <ArrowLeft className="h-3 w-3 mr-1" />
-                {contentLanguage === 'en' ? 'Back' : contentLanguage === 'te' ? 'వెనుకకు' : contentLanguage === 'kn' ? 'ಹಿಂದಕ್ಕೆ' : 'मागे'}
-              </Button>
-            </div>
-          )}
           <CountdownTimer
             initialCount={3}
             onComplete={handleCountdownComplete}

--- a/src/lib/axl-explorations/src/components/games/CombinedWordGamesPreview.tsx
+++ b/src/lib/axl-explorations/src/components/games/CombinedWordGamesPreview.tsx
@@ -930,17 +930,6 @@ export function CombinedWordGamesPreview({
     return (
       <div className="h-screen bg-gradient-cool p-2 sm:p-3 md:p-4 overflow-hidden flex flex-col">
         <div className="max-w-7xl mx-auto w-full flex-1 flex flex-col min-h-0 overflow-hidden">
-          {!hideHeader && (
-            <div className="flex items-center justify-between mb-3 flex-shrink-0">
-              <Button
-                onClick={handleBack}
-                className="bg-white/20 backdrop-blur-sm text-white hover:bg-white/30 border border-white/20 text-sm px-3 py-2"
-              >
-                <ArrowLeft className="h-3 w-3 mr-1" />
-                {contentLanguage === 'en' ? 'Back' : contentLanguage === 'te' ? 'వెనుకకు' : contentLanguage === 'kn' ? 'ಹಿಂದಕ್ಕೆ' : 'मागे'}
-              </Button>
-            </div>
-          )}
           <CountdownTimer
             initialCount={3}
             onComplete={handleCountdownComplete}

--- a/src/lib/axl-explorations/src/components/games/FillInBlanksGamePreview.tsx
+++ b/src/lib/axl-explorations/src/components/games/FillInBlanksGamePreview.tsx
@@ -435,17 +435,6 @@ export function FillInBlanksGamePreview({
     return (
       <div className="h-screen bg-gradient-cool p-2 sm:p-3 md:p-4 overflow-hidden flex flex-col">
         <div className="max-w-7xl mx-auto w-full flex-1 flex flex-col min-h-0 overflow-hidden">
-          {!hideHeader && (
-            <div className="flex items-center justify-between mb-3 flex-shrink-0">
-              <Button
-                onClick={handleBack}
-                className="bg-white/20 backdrop-blur-sm text-white hover:bg-white/30 border border-white/20 text-sm px-3 py-2"
-              >
-                <ArrowLeft className="h-3 w-3 mr-1" />
-                {contentLanguage === 'en' ? 'Back' : contentLanguage === 'te' ? 'వెనుకకు' : contentLanguage === 'kn' ? 'ಹಿಂದಕ್ಕೆ' : 'मागे'}
-              </Button>
-            </div>
-          )}
           <CountdownTimer
             initialCount={3}
             onComplete={handleCountdownComplete}

--- a/src/lib/axl-explorations/src/components/games/LetterGamePreview.tsx
+++ b/src/lib/axl-explorations/src/components/games/LetterGamePreview.tsx
@@ -557,23 +557,6 @@ export function LetterGamePreview({
     return (
       <div className="h-screen bg-gradient-cool p-2 sm:p-3 md:p-4 overflow-hidden flex flex-col">
         <div className="max-w-7xl mx-auto w-full flex-1 flex flex-col min-h-0 overflow-hidden">
-          {!hideHeader && (
-            <div className="flex items-center justify-between mb-3 flex-shrink-0">
-              <Button
-                onClick={handleBack}
-                className="bg-white/20 backdrop-blur-sm text-white hover:bg-white/30 border border-white/20 text-sm px-3 py-2"
-              >
-                <ArrowLeft className="h-3 w-3 mr-1" />
-                {contentLanguage === "en"
-                  ? "Back"
-                  : contentLanguage === "te"
-                  ? "వెనుకకు"
-                  : contentLanguage === "kn"
-                  ? "ಹಿಂದಕ್ಕೆ"
-                  : "मागे"}
-              </Button>
-            </div>
-          )}
           <CountdownTimer
             initialCount={3}
             onComplete={handleCountdownComplete}

--- a/src/lib/axl-explorations/src/components/games/MemoryGamePreview.tsx
+++ b/src/lib/axl-explorations/src/components/games/MemoryGamePreview.tsx
@@ -468,17 +468,6 @@ export function MemoryGamePreview({
     return (
       <div className="h-screen bg-gradient-cool p-2 sm:p-3 md:p-4 overflow-hidden flex flex-col">
         <div className="max-w-7xl mx-auto w-full flex-1 flex flex-col min-h-0 overflow-hidden">
-          {!hideHeader && (
-            <div className="flex items-center justify-between mb-3 flex-shrink-0">
-              <Button
-                onClick={handleBack}
-                className="bg-white/20 backdrop-blur-sm text-white hover:bg-white/30 border border-white/20 text-sm px-3 py-2"
-              >
-                <ArrowLeft className="h-3 w-3 mr-1" />
-                {contentLanguage === 'en' ? 'Back' : contentLanguage === 'te' ? 'వెనుకకు' : contentLanguage === 'kn' ? 'ಹಿಂದಕ್ಕೆ' : 'मागे'}
-              </Button>
-            </div>
-          )}
           <CountdownTimer
             initialCount={3}
             onComplete={handleCountdownComplete}

--- a/src/lib/axl-explorations/src/components/games/ROARPhonemeGamePreview.tsx
+++ b/src/lib/axl-explorations/src/components/games/ROARPhonemeGamePreview.tsx
@@ -529,17 +529,6 @@ export function ROARPhonemeGamePreview({
     return (
       <div className="h-screen bg-gradient-cool p-2 sm:p-3 md:p-4 overflow-hidden flex flex-col">
         <div className="max-w-7xl mx-auto w-full flex-1 flex flex-col min-h-0 overflow-hidden">
-          {!hideHeader && (
-            <div className="flex items-center justify-between mb-3 flex-shrink-0">
-              <Button
-                onClick={handleBack}
-                className="bg-white/20 backdrop-blur-sm text-white hover:bg-white/30 border border-white/20 text-sm px-3 py-2"
-              >
-                <ArrowLeft className="h-3 w-3 mr-1" />
-                {contentLanguage === 'en' ? 'Back' : contentLanguage === 'te' ? 'వెనుకకు' : contentLanguage === 'kn' ? 'ಹಿಂದಕ್ಕೆ' : 'मागे'}
-              </Button>
-            </div>
-          )}
           <CountdownTimer
             initialCount={3}
             onComplete={handleCountdownComplete}

--- a/src/lib/axl-explorations/src/components/games/ROARPictureVocabGamePreview.tsx
+++ b/src/lib/axl-explorations/src/components/games/ROARPictureVocabGamePreview.tsx
@@ -443,17 +443,6 @@ export function ROARPictureVocabGamePreview({
     return (
       <div className="h-screen bg-gradient-cool p-2 sm:p-3 md:p-4 overflow-hidden flex flex-col">
         <div className="max-w-7xl mx-auto w-full flex-1 flex flex-col min-h-0 overflow-hidden">
-          {!hideHeader && (
-            <div className="flex items-center justify-between mb-3 flex-shrink-0">
-              <Button
-                onClick={handleBack}
-                className="bg-white/20 backdrop-blur-sm text-white hover:bg-white/30 border border-white/20 text-sm px-3 py-2"
-              >
-                <ArrowLeft className="h-3 w-3 mr-1" />
-                {contentLanguage === 'en' ? 'Back' : contentLanguage === 'te' ? 'వెనుకకు' : contentLanguage === 'kn' ? 'ಹಿಂದಕ್ಕೆ' : 'मागे'}
-              </Button>
-            </div>
-          )}
           <CountdownTimer
             initialCount={3}
             onComplete={handleCountdownComplete}

--- a/src/lib/axl-explorations/src/components/games/ROARRapidVisualGamePreview.tsx
+++ b/src/lib/axl-explorations/src/components/games/ROARRapidVisualGamePreview.tsx
@@ -474,17 +474,6 @@ function ROARRapidVisualGamePreview({
     return (
       <div className="h-screen bg-gradient-cool p-2 sm:p-3 md:p-4 overflow-hidden flex flex-col">
         <div className="max-w-7xl mx-auto w-full flex-1 flex flex-col min-h-0 overflow-hidden">
-          {!hideHeader && (
-            <div className="flex items-center justify-between mb-3 flex-shrink-0">
-              <Button
-                onClick={handleBack}
-                className="bg-white/20 backdrop-blur-sm text-white hover:bg-white/30 border border-white/20 text-sm px-3 py-2"
-              >
-                <ArrowLeft className="h-3 w-3 mr-1" />
-                {contentLanguage === 'en' ? 'Back' : contentLanguage === 'te' ? 'వెనుకకు' : contentLanguage === 'kn' ? 'ಹಿಂದಕ್ಕೆ' : 'मागे'}
-              </Button>
-            </div>
-          )}
           <CountdownTimer
             initialCount={3}
             onComplete={handleCountdownComplete}

--- a/src/lib/axl-explorations/src/components/games/ROARWordGamePreview.tsx
+++ b/src/lib/axl-explorations/src/components/games/ROARWordGamePreview.tsx
@@ -434,17 +434,6 @@ export function ROARWordGamePreview({
     return (
       <div className="h-screen bg-gradient-cool p-2 sm:p-3 md:p-4 overflow-hidden flex flex-col">
         <div className="max-w-7xl mx-auto w-full flex-1 flex flex-col min-h-0 overflow-hidden">
-          {!hideHeader && (
-            <div className="flex items-center justify-between mb-3 flex-shrink-0">
-              <Button
-                onClick={handleBack}
-                className="bg-white/20 backdrop-blur-sm text-white hover:bg-white/30 border border-white/20 text-sm px-3 py-2"
-              >
-                <ArrowLeft className="h-3 w-3 mr-1" />
-                {contentLanguage === 'en' ? 'Back' : contentLanguage === 'te' ? 'వెనుకకు' : contentLanguage === 'kn' ? 'ಹಿಂದಕ್ಕೆ' : 'मागे'}
-              </Button>
-            </div>
-          )}
           <CountdownTimer
             initialCount={3}
             onComplete={handleCountdownComplete}

--- a/src/lib/axl-explorations/src/components/games/SentenceGamePreview.tsx
+++ b/src/lib/axl-explorations/src/components/games/SentenceGamePreview.tsx
@@ -440,17 +440,6 @@ export function SentenceGamePreview({
     return (
       <div className="h-screen bg-gradient-cool p-2 sm:p-3 md:p-4 overflow-hidden flex flex-col">
         <div className="max-w-7xl mx-auto w-full flex-1 flex flex-col min-h-0 overflow-hidden">
-          {!hideHeader && (
-            <div className="flex items-center justify-between mb-3 flex-shrink-0">
-              <Button
-                onClick={handleBack}
-                className="bg-white/20 backdrop-blur-sm text-white hover:bg-white/30 border border-white/20 text-sm px-3 py-2"
-              >
-                <ArrowLeft className="h-3 w-3 mr-1" />
-                {contentLanguage === 'en' ? 'Back' : contentLanguage === 'te' ? 'వెనుకకు' : contentLanguage === 'kn' ? 'ಹಿಂದಕ್ಕೆ' : 'మాగे'}
-              </Button>
-            </div>
-          )}
           <CountdownTimer
             initialCount={3}
             onComplete={handleCountdownComplete}

--- a/src/lib/axl-explorations/src/components/games/TrueFalseGamePreview.tsx
+++ b/src/lib/axl-explorations/src/components/games/TrueFalseGamePreview.tsx
@@ -410,17 +410,6 @@ export function TrueFalseGamePreview({
     return (
       <div className="h-screen bg-gradient-cool p-2 sm:p-3 md:p-4 overflow-hidden flex flex-col">
         <div className="max-w-7xl mx-auto w-full flex-1 flex flex-col min-h-0 overflow-hidden">
-          {!hideHeader && (
-            <div className="flex items-center justify-between mb-3 flex-shrink-0">
-              <Button
-                onClick={handleBack}
-                className="bg-white/20 backdrop-blur-sm text-white hover:bg-white/30 border border-white/20 text-sm px-3 py-2"
-              >
-                <ArrowLeft className="h-3 w-3 mr-1" />
-                {contentLanguage === 'en' ? 'Back' : contentLanguage === 'te' ? 'వెనుకకు' : contentLanguage === 'kn' ? 'ಹಿಂದಕ್ಕೆ' : 'मागे'}
-              </Button>
-            </div>
-          )}
           <CountdownTimer
             initialCount={3}
             onComplete={handleCountdownComplete}


### PR DESCRIPTION
Removes the header/back button from the blue countdown screen (previewPhase === 'countdown') across all 11 game preview components so it is hidden during the 3-2-1 timer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the back button from countdown screens across all game types, providing a cleaner countdown experience without navigation elements during the timer display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->