### PR TITLE
fix: wrap App in MemoryRouter to fix failing App.test.js

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -6,6 +6,7 @@ import React from "react";
 import { render } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { configureStore } from "@reduxjs/toolkit";
+import { MemoryRouter } from "react-router-dom";
 
 // ─── Test ─────────────────────────────────────────────────────────────────
 
@@ -57,7 +58,9 @@ test("App renders without crashing", () => {
   expect(() =>
     render(
       <Provider store={store}>
-        <App />
+        <MemoryRouter>
+          <App />
+        </MemoryRouter>
       </Provider>
     )
   ).not.toThrow();


### PR DESCRIPTION
### Issue
The "Run Tests" CI step was failing, which blocked deployment.

App.test.js rendered <App /> with only the Redux Provider — no Router.
But App calls useNavigate() at the top level, which only works inside a
Router. So the test threw:

  "useNavigate() may be used only in the context of a <Router> component."

Result: 1 failed, 166 passed → CI exits 1 → deploy stops.

### Root cause
This is a test setup gap, not an app bug. In production, index.js already
wraps App in <BrowserRouter>, so useNavigate() works at runtime. The test
just didn't reproduce that Router context.

### Fix
Wrap the render in <MemoryRouter> (the test-equivalent of BrowserRouter)
to mirror production. No app code changed.

### Result
All 167 tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the app smoke test to ensure router-dependent functionality is properly exercised during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->