### PR TITLE
ALL-264: improved bubble-game letter hunt, adjust desktop layouts, and reposition f2 barakhadi bear

### DIFF
--- a/src/RFlow/Barakhadi.jsx
+++ b/src/RFlow/Barakhadi.jsx
@@ -5795,7 +5795,7 @@ const Barakhadi = ({
             alt="bear"
             style={{
               position: "absolute",
-              bottom: isMobile ? "10px" : "1px",
+              bottom: isMobile ? "-45px" : "1px",
               right: isMobile ? "10px" : "40px",
               width: isMobile ? "15dvw" : "9dvw",
               zIndex: isMobile ? 11 : 1,

--- a/src/components/Practice/AserFlow.jsx
+++ b/src/components/Practice/AserFlow.jsx
@@ -99,6 +99,7 @@ const AserFlow = ({
   hideContentDuringDemo = false,
   blockProgression = false,
   hideProgress = false,
+  showSpeakerPointer = false,
 }) => {
   const [currentIndex, setCurrentIndex] = useState(0);
   const [selectedLetter, setSelectedLetter] = useState("");
@@ -538,7 +539,8 @@ const AserFlow = ({
         style={{
           width: "100%",
           height: isMobile ? "100%" : "auto",
-          margin: isMobile ? "0" : "10px 0",
+          margin: isMobile ? "0" : "70px 0 10px 0",
+          paddingBottom: isMobile ? "0px" : "65px",
           background: "#fff",
           display: "flex",
           flexDirection: "column",
@@ -685,7 +687,7 @@ const AserFlow = ({
           style={{
             position: "relative",
             width: "100%",
-            height: isMobile ? "270px" : "min(350px, 40vh)",
+            height: isMobile ? "270px" : "min(280px, 32vh)",
             //background: "#fff",
             borderRadius: "20px",
             //boxShadow: "0px 2px 10px rgba(0,0,0,0.2)",
@@ -724,7 +726,7 @@ const AserFlow = ({
                   { top: "20%", left: "40%" },
                   { top: "75%", left: "43%" },
                   { top: "79%", left: "61%" },
-                  { top: "83%", left: "30%" },
+                  { top: "98%", left: "30%" },
                 ];
 
             const pos = positions[index % positions.length];
@@ -913,6 +915,32 @@ const AserFlow = ({
             >
               <ListenButton height={50} width={50} />
             </Box>
+            {showSpeakerPointer && (
+              <div
+                style={{
+                  position: "absolute",
+                  top: "100%",
+                  left: 0,
+                  width: "100%",
+                  display: "flex",
+                  justifyContent: "center",
+                  marginTop: "3px",
+                  zIndex: 10000,
+                  pointerEvents: "none",
+                }}
+              >
+                <div
+                  style={{
+                    fontSize: isMobile ? "40px" : "64px",
+                    animation:
+                      "pointToButton 1.5s ease-in-out infinite, bounce 1s ease-in-out infinite",
+                    filter: "drop-shadow(0 4px 6px rgba(0,0,0,0.3))",
+                  }}
+                >
+                  👇
+                </div>
+              </div>
+            )}
           </Box>
           {/* Show next button only after completing all items (hide in demo mode) */}
           {(() => {

--- a/src/components/Practice/AserFlowPreview.jsx
+++ b/src/components/Practice/AserFlowPreview.jsx
@@ -338,6 +338,12 @@ const AserFlowPreview = ({ onStartGame, onBack }) => {
         hideContentDuringDemo={demoPhase === "countdown"}
         blockProgression={blockGameProgression}
         hideProgress={true}
+        showSpeakerPointer={
+          showPointer &&
+          demoPhase === "demo" &&
+          !isInstructionPlaying &&
+          pointerTarget === "speaker"
+        }
       />
 
       {/* "How to Play" Progress Indicator */}
@@ -349,7 +355,7 @@ const AserFlowPreview = ({ onStartGame, onBack }) => {
             boxShadow: "0 4px 12px rgba(0,0,0,0.15)",
             padding: isMobile ? "8px 12px" : "16px 24px",
             position: "absolute",
-            top: isMobile ? "80px" : "min(160px, 22vh)",
+            top: isMobile ? "80px" : "min(110px, 15vh)",
             borderRadius: "12px",
             zIndex: 10000,
             left: "50%",
@@ -449,28 +455,6 @@ const AserFlowPreview = ({ onStartGame, onBack }) => {
           </button>
         </div>
       )}
-
-      {/* Pointer - Only for speaker button */}
-      {showPointer &&
-        demoPhase === "demo" &&
-        !isInstructionPlaying &&
-        pointerTarget === "speaker" && (
-          <div
-            style={{
-              position: "absolute",
-              bottom: isMobile ? "80px" : "min(130px, 17vh)",
-              left: isMobile ? "calc(50% - 20px)" : "calc(50% - 35px)",
-              zIndex: 10000,
-              fontSize: isMobile ? "40px" : "64px",
-              animation:
-                "pointToButton 1.5s ease-in-out infinite, bounce 1s ease-in-out infinite",
-              pointerEvents: "none",
-              filter: "drop-shadow(0 4px 6px rgba(0,0,0,0.3))",
-            }}
-          >
-            👇
-          </div>
-        )}
 
       {/* Completion Screen */}
       {demoPhase === "completion" && (

--- a/src/utils/SpeedSelector.js
+++ b/src/utils/SpeedSelector.js
@@ -65,8 +65,8 @@ const SpeedSelector = ({
         ...(!horizontal && floated
           ? {
               position: "absolute",
-              right: "20px",
-              top: "59%",
+              right: "90px",
+              top: "53%",
               transform: "translateY(-50%)",
             }
           : {}),


### PR DESCRIPTION
- Moved the hand pointer component from AserFlowPreview to inside AserFlow relative to the speaker button to ensure a consistent 3px gap across all devices.
- Prevented pointer clipping on desktop by adding padding to the main content container and scaling the Bubble Area height to fit within Card boundaries.
- Adjusted SpeedSelector alignment on desktop by shifting its absolute position 20px to the left (setting right: 90px, top: 53%).
- Repositioned the teddy bear in Barakhadi mobile view to -45px bottom to align properly.
