### PR TITLE
ALL-417: Removed the App Bar in the desktop and move the logout button to the bottom

### DIFF
--- a/src/components/Assesment/Assesment.jsx
+++ b/src/components/Assesment/Assesment.jsx
@@ -1629,29 +1629,28 @@ export const ProfileHeader = ({
                 />
               </IconButton>
             </CustomTooltip>
-            {process.env.REACT_APP_IS_IN_APP_AUTHORISATION === "true" &&
-              process.env.REACT_APP_IS_APP_IFRAME !== "true" && (
-                <CustomTooltip title={ui.ASSESSMENT_LOGOUT}>
-                  <IconButton
-                    onClick={handleLogout}
-                    sx={{
-                      mr: { xs: "5px", sm: "10px" },
-                      padding: isMobile ? "6px" : "8px",
-                      backgroundColor: "rgba(255, 255, 255, 0.7)",
-                      "&:hover": {
-                        backgroundColor: "rgba(255, 255, 255, 0.9)",
-                      },
-                    }}
-                  >
-                    <img
-                      className="logout-img"
-                      style={{ height: 25, width: 25 }}
-                      src={LogoutImg}
-                      alt="Logout"
-                    />
-                  </IconButton>
-                </CustomTooltip>
-              )}
+            {process.env.REACT_APP_IS_IN_APP_AUTHORISATION === "true" && (
+              <CustomTooltip title={ui.ASSESSMENT_LOGOUT}>
+                <IconButton
+                  onClick={handleMenuLogout}
+                  sx={{
+                    mr: { xs: "5px", sm: "10px" },
+                    padding: isMobile ? "6px" : "8px",
+                    backgroundColor: "rgba(255, 255, 255, 0.7)",
+                    "&:hover": {
+                      backgroundColor: "rgba(255, 255, 255, 0.9)",
+                    },
+                  }}
+                >
+                  <img
+                    className="logout-img"
+                    style={{ height: 25, width: 25 }}
+                    src={LogoutImg}
+                    alt="Logout"
+                  />
+                </IconButton>
+              </CustomTooltip>
+            )}
           </Box>
         )}
       </Box>


### PR DESCRIPTION
## Summary
Removed the parent (AXL) App Bar for ALL . Logout is now served from inside
the ALL app — the desktop logout icon and the mobile hamburger menu.

## Changes
- Desktop logout icon: shown in embedded mode too (not just standalone).
- Logout (desktop + mobile) uses one handler:
    - Embedded: asks the parent to run the existing logout handshake (end session, redirect to /login).
    - Standalone: local logout (clear storage, redirect to /login).
- Companion change in ts-axl-app: App Bar commented out; parent handles the logout request.

## Testing
- [x] Embedded desktop: header logout → parent ends session → /login.
- [x] Embedded mobile: menu logout → same.
- [x] Standalone: logout works to /login.
-
[Screencast from 23-06-26 05:12:19 PM IST.webm](https://github.com/user-attachments/assets/7fd175f3-ec7d-4e8e-baad-63c3e8f78828)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logout functionality across various deployment contexts. The logout button now correctly handles in-app authorization scenarios and provides enhanced support for iframe-based environments. The logout mechanism has been refined to use the appropriate messaging system for seamless and proper authentication handling and communication across different deployment configurations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->