### PR TITLE
ALL-416 : Continue button in english on apply levels

### DIFF
--- a/src/lib/axl-explorations/src/components/games/LetterGame.tsx
+++ b/src/lib/axl-explorations/src/components/games/LetterGame.tsx
@@ -16,6 +16,7 @@ import { Language, getNativeLanguageName } from "../../constants/languages";
 import { sessionManager } from "../../utils/sessionManager";
 import { sessionTelemetryManager } from "../../utils/sessionTelemetryManager";
 import { trackingAssessmentService, QuestionSummary } from "../../utils/trackingAssessmentService";
+import { getUiStrings } from "../../../../../constants/strings";
 
 // Extended question interface for multilingual support
 interface MultilingualLetterQuestion extends LetterHuntQuestion {
@@ -1147,7 +1148,7 @@ export function LetterGame({ onBack, initialLevel, startLevel, endLevel, disable
           // (handled in the level completion logic around line 699)
           // The "Next Level" button is for transitioning TO the next level, not completing it
         }}
-        continueButtonText={shouldShowContinue ? "Continue" : undefined}
+        continueButtonText={shouldShowContinue ? getUiStrings(selectedLanguage || 'en').COMMON_CONTINUE : undefined}
       />
     );
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Localized the “Continue” button on the success screen so it now appears in the correct language for each user.
  * Improved consistency of on-screen text across supported locales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->