### PR TITLE
ALL-414 Skip red/green answer colors on Firefox and Android devices

### DIFF
--- a/src/components/Mechanism/WordsOrImage.jsx
+++ b/src/components/Mechanism/WordsOrImage.jsx
@@ -198,6 +198,12 @@ const WordsOrImage = ({
   const multilingualLangCode = getMultilingualLangCode();
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
   const isTablet = useMediaQuery(theme.breakpoints.between("sm", "md"));
+  const isFirefox =
+    typeof navigator !== "undefined" &&
+    navigator.userAgent.toLowerCase().includes("firefox");
+  const isAndroid =
+    typeof navigator !== "undefined" && /Android/i.test(navigator.userAgent);
+  const skipAnswerColor = isFirefox || isAndroid;
   const [abusiveFound, setAbusiveFound] = useState(false);
   const [detectedWord, setDetectedWord] = useState("");
   const [language, setLanguage] = useState(getLocalData("lang") || "en");
@@ -672,14 +678,7 @@ const WordsOrImage = ({
   };
 
   const getAnswerColor = (answer) => {
-    // const isFirefox =
-    //   typeof navigator !== "undefined" &&
-    //   navigator.userAgent.toLowerCase().includes("firefox");
-
-    // if (isFirefox && (answer === true || answer === false)) {
-    //   return "green";
-    // }
-
+    if (skipAnswerColor) return "#333F61";
     if (answer === true) return "green";
     if (answer === false) return "red";
     return "#333F61";
@@ -1266,12 +1265,13 @@ const WordsOrImage = ({
                         fontFamily: getFontFamily(language),
                         lineHeight: isMobile ? "1.4" : "50px",
                         //background: "#FFF0BD",
-                        color:
-                          isTranscriptCorrect === true
-                            ? "green"
-                            : isTranscriptCorrect === false
-                            ? "red" // todo: need to change to red
-                            : "#333F61",
+                        color: skipAnswerColor
+                          ? "#333F61"
+                          : isTranscriptCorrect === true
+                          ? "green"
+                          : isTranscriptCorrect === false
+                          ? "red"
+                          : "#333F61",
                         display: isMobile ? "flex" : undefined,
                         flexDirection: isMobile ? "column" : undefined,
                         alignItems: isMobile ? "center" : undefined,


### PR DESCRIPTION
Answer feedback colors are unreliable on Firefox (speech recognition always forced correct) and Android (inaccurate match scores), so suppress color changes on these platforms by returning neutral color #333F61.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved answer and transcript color handling for Firefox and Android, where the app now uses a neutral color instead of correctness-based green/red states.
  * Updated matched text highlighting to follow the same behavior, keeping colors consistent across supported browsers and cases where correctness is not yet determined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->