### PR TITLE
ALL-420 : when user land in m2-m4 from discovery no addLesson is called

### DIFF
--- a/src/components/DiscoverSentance/DiscoverSentance.jsx
+++ b/src/components/DiscoverSentance/DiscoverSentance.jsx
@@ -380,6 +380,17 @@ const SpeakSentenceComponent = () => {
           language: lang,
           milestoneLevel: "m0",
         });
+        const resolvedNext = resolveAfterSetComplete(newHistory);
+        if (resolvedNext.type === "terminal" && getSetData?.currentLevel) {
+          await addLesson({
+            sessionId,
+            milestone: `practice`,
+            lesson: "0",
+            progress: 0,
+            language: lang,
+            milestoneLevel: getSetData.currentLevel,
+          });
+        }
         await loadDiscoveryNextSet(newHistory, assessmentResponse);
       }
     } catch (error) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the flow after completing the last question in a discovery set.
  * Added a milestone record when the next step is a terminal outcome, ensuring progress is captured correctly before moving on.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->