### PR TITLE
ALL-463: Fixed the Audio Wave Popup Overlaps Buttons in FluencyP1  Practice & Phrases In Action

### DIFF
--- a/src/components/Practice/AudioTooltipModal.jsx
+++ b/src/components/Practice/AudioTooltipModal.jsx
@@ -34,6 +34,7 @@ const AudioTooltipModal = ({ audioSrc, description, children }) => {
         `${process.env.REACT_APP_AWS_S3_BUCKET_CONTENT_URL}/multilingual_audios/${audioSrc}`
       );
       audioRef.current = audio;
+      audio.onended = () => setShowModal(false);
       audio.play().catch((err) => console.log("Audio play error:", err));
     } else {
       if (audioRef.current) {

--- a/src/components/Practice/AudioTooltipModal.jsx
+++ b/src/components/Practice/AudioTooltipModal.jsx
@@ -61,58 +61,67 @@ const AudioTooltipModal = ({ audioSrc, description, children }) => {
   return (
     <div
       ref={containerRef}
-      style={{ position: "relative", display: "inline-block" }}
+      style={{
+        position: "relative",
+        display: "inline-block",
+        marginBottom: showModal ? "65px" : "0px",
+        transition: "margin-bottom 0.25s ease-in-out",
+      }}
       onMouseEnter={() => !isTouchDevice && setShowModal(true)}
       onMouseLeave={() => !isTouchDevice && setShowModal(false)}
       onClick={handleClick}
     >
       {children}
 
-      {showModal && (
-        <div
-          onClick={(e) => e.stopPropagation()}
-          style={{
-            position: "absolute",
-            top: "100%",
-            left: "50%",
-            transform: "translateX(-50%)",
-            //width: "150px",
-            background: "#fff",
-            border: "2px solid #ff8c52",
-            borderRadius: "16px",
-            boxShadow: "0px 0px 20px 10px #FF7F367A",
-            padding: "10px 0px",
-            marginTop: "8px",
-            zIndex: 1000,
-            textAlign: "center",
-          }}
-        >
-          <div>
-            <Box
-              className="walkthrough-step-1"
-              sx={{
-                //marginTop: "7px",
-                position: "relative",
-                display: "flex",
-                justifyContent: "center",
-                alignItems: "center",
-                //minWidth: { xs: "50px", sm: "60px", md: "70px" },
-                cursor: "pointer",
-              }}
-              onClick={() => {
-                // playWordAudio(
-                //   `${process.env.REACT_APP_AWS_S3_BUCKET_CONTENT_URL}/mechanics_audios/${"text"}`
-                // );
-              }}
-            >
-              <img
-                src={Assets.graph}
-                alt="graph"
-                style={{ height: "40px", margin: "10px" }}
-              />
-            </Box>
-          </div>
-          {/* <div
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          position: "absolute",
+          top: "100%",
+          left: "50%",
+          transform: showModal
+            ? "translateX(-50%) translateY(0) scale(1)"
+            : "translateX(-50%) translateY(-10px) scale(0.95)",
+          opacity: showModal ? 1 : 0,
+          pointerEvents: showModal ? "auto" : "none",
+          visibility: showModal ? "visible" : "hidden",
+          transition:
+            "opacity 0.25s cubic-bezier(0.4, 0, 0.2, 1), transform 0.25s cubic-bezier(0.4, 0, 0.2, 1), visibility 0.25s",
+          //width: "150px",
+          background: "#fff",
+          border: "2px solid #ff8c52",
+          borderRadius: "16px",
+          boxShadow: "0px 0px 20px 2px #FF7F367A",
+          padding: "10px 0px",
+          marginTop: "8px",
+          zIndex: 1000,
+          textAlign: "center",
+          width: "180px",
+          height: "50px",
+        }}
+      >
+        <div>
+          <Box
+            className="walkthrough-step-1"
+            sx={{
+              //marginTop: "7px",
+              position: "relative",
+              display: "flex",
+              justifyContent: "center",
+              alignItems: "center",
+              //minWidth: { xs: "50px", sm: "60px", md: "70px" },
+              cursor: "pointer",
+            }}
+            onClick={() => {
+              // playWordAudio(
+              //   `${process.env.REACT_APP_AWS_S3_BUCKET_CONTENT_URL}/mechanics_audios/${"text"}`
+              // );
+            }}
+          >
+            <img src={Assets.graph} alt="graph" style={{ height: "30px" }} />
+          </Box>
+        </div>
+        {/* <div
             style={{
               width: "100%",
               height: "1.5px",
@@ -124,8 +133,7 @@ const AudioTooltipModal = ({ audioSrc, description, children }) => {
           <p style={{ fontSize: "18px", color: "#333", margin: 15, fontStyle: "Quicksand", fontWeight: "600" }}>
             {description}
           </p> */}
-        </div>
-      )}
+      </div>
     </div>
   );
 };

--- a/src/components/Practice/AudioTooltipModal.jsx
+++ b/src/components/Practice/AudioTooltipModal.jsx
@@ -64,7 +64,7 @@ const AudioTooltipModal = ({ audioSrc, description, children }) => {
       style={{
         position: "relative",
         display: "inline-block",
-        marginBottom: showModal ? "65px" : "0px",
+        marginBottom: showModal ? "4.06rem" : "0px",
         transition: "margin-bottom 0.25s ease-in-out",
       }}
       onMouseEnter={() => !isTouchDevice && setShowModal(true)}

--- a/src/components/Practice/FluencyP1.jsx
+++ b/src/components/Practice/FluencyP1.jsx
@@ -788,7 +788,7 @@ const FluencyP1 = ({
                     height: "50px",
                     cursor: "pointer",
                     order: isMobile ? 2 : undefined,
-                    marginTop: isMobile ? "30px" : undefined,
+                    marginTop: isMobile ? "55px" : "auto",
                   }}
                 />
               )}


### PR DESCRIPTION
Resolved layout overlap issues caused by floating audio waveform popups:
- FluencyP1: Repositioned the pronunciation popup directly below the selected word and locked its dimensions to a fixed size for visual consistency.
- AudioTooltipModal (PhrasesInAction): Standardized the popup size to 180x50px, added a dynamic bottom margin to push elements beneath it down when open, and implemented a smooth slide-and-fade transition effect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dismiss the audio tooltip/modal automatically when the audio finishes.
  * Improved tooltip transitions and interaction handling using smoother visibility and pointer behavior.
  * Refined tooltip spacing, shadow styling, and sizing for more consistent presentation.
  * Adjusted “listen” icon alignment on both mobile and non-mobile layouts for better spacing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->