### PR TITLE
ALL-481-hotfix: updated the responsive text line-height for M9 p1

### DIFF
--- a/src/components/Layout/MainLayout.jsx
+++ b/src/components/Layout/MainLayout.jsx
@@ -1120,7 +1120,15 @@ const MainLayout = (props) => {
                     overflowY: "hidden",
                     opacity: disableScreen ? 0.25 : 1,
                     pointerEvents: disableScreen ? "none" : "initial",
-                    padding: { xs: "16px !important", md: "24px !important" },
+                    padding:
+                      contentType &&
+                      contentType.toLowerCase() !== "word" &&
+                      startShowCase
+                        ? {
+                            xs: "5rem 1rem 1rem !important",
+                            md: "8.125rem 1.5rem 1.5rem !important",
+                          }
+                        : { xs: "1rem !important", md: "1.5rem !important" },
                     boxSizing: "border-box",
                     ...props.cardContentStyle,
                   }}

--- a/src/components/Layout/MainLayout.jsx
+++ b/src/components/Layout/MainLayout.jsx
@@ -1120,15 +1120,12 @@ const MainLayout = (props) => {
                     overflowY: "hidden",
                     opacity: disableScreen ? 0.25 : 1,
                     pointerEvents: disableScreen ? "none" : "initial",
-                    padding:
-                      contentType &&
-                      contentType.toLowerCase() !== "word" &&
-                      startShowCase
-                        ? {
-                            xs: "5rem 1rem 1rem !important",
-                            md: "8.125rem 1.5rem 1.5rem !important",
-                          }
-                        : { xs: "1rem !important", md: "1.5rem !important" },
+                    padding: startShowCase
+                      ? {
+                          xs: "5rem 1rem 1rem !important",
+                          md: "8.125rem 1.5rem 1.5rem !important",
+                        }
+                      : { xs: "1rem !important", md: "1.5rem !important" },
                     boxSizing: "border-box",
                     ...props.cardContentStyle,
                   }}

--- a/src/components/Mechanism/WordsOrImage.jsx
+++ b/src/components/Mechanism/WordsOrImage.jsx
@@ -1124,7 +1124,7 @@ const WordsOrImage = ({
                             : "clamp(1.6rem, 2.5vw, 3.8rem)",
                           fontWeight: language === "te" ? 400 : 700,
                           fontFamily: getFontFamily(language),
-                          lineHeight: 1.4,
+                          lineHeight: { xs: 1.4, md: "4.5rem" },
                           ...(mechanism_id === "mechanic_15"
                             ? {
                                 position: "relative",

--- a/src/views/Practice/Practice.jsx
+++ b/src/views/Practice/Practice.jsx
@@ -66,6 +66,8 @@ import { levels, levelTwo, levelThree } from "../../data/practiceContent";
 import { onLocalData } from "../../utils/localStorageEvents";
 import { useAlphabetDemo } from "../../context/AlphabetDemoContext";
 
+const PRACTICE_LINE_HEIGHT = { xs: "1.4", md: "4.5rem" };
+
 // ─── Lazy-loaded activity components (one chunk each) ────────────────────────
 const Mechanics2 = lazy(() => import("../../components/Practice/Mechanics2"));
 const Mechanics3 = lazy(() => import("../../components/Practice/Mechanics3"));
@@ -3708,7 +3710,7 @@ const Practice = () => {
                         : "clamp(1.6rem, 2.5vw, 3.8rem)",
                     fontWeight: lang === "te" ? 400 : 700,
                     fontFamily: getFontFamily(lang),
-                    lineHeight: "50px",
+                    lineHeight: PRACTICE_LINE_HEIGHT,
                     background: "#FFF0BD",
                     color: color,
                   }}
@@ -3736,7 +3738,7 @@ const Practice = () => {
                       : "clamp(1.6rem, 2.5vw, 3.8rem)",
                   fontWeight: 700,
                   fontFamily: getFontFamily(lang),
-                  lineHeight: "50px",
+                  lineHeight: PRACTICE_LINE_HEIGHT,
                 }}
               >
                 {i === 0 ? word[i].toUpperCase() : word[i]}
@@ -3765,7 +3767,7 @@ const Practice = () => {
                       : "clamp(1.6rem, 2.5vw, 3.8rem)",
                   fontWeight: 700,
                   fontFamily: getFontFamily(lang),
-                  lineHeight: "50px",
+                  lineHeight: PRACTICE_LINE_HEIGHT,
                   background: "#FFF0BD",
                 }}
               >
@@ -3787,7 +3789,7 @@ const Practice = () => {
                     : "clamp(1.6rem, 2.5vw, 3.8rem)",
                 fontWeight: 700,
                 fontFamily: getFontFamily(lang),
-                lineHeight: "50px",
+                lineHeight: PRACTICE_LINE_HEIGHT,
               }}
               key={index}
             >

--- a/src/views/Practice/Practice.jsx
+++ b/src/views/Practice/Practice.jsx
@@ -66,8 +66,6 @@ import { levels, levelTwo, levelThree } from "../../data/practiceContent";
 import { onLocalData } from "../../utils/localStorageEvents";
 import { useAlphabetDemo } from "../../context/AlphabetDemoContext";
 
-const PRACTICE_LINE_HEIGHT = { xs: "1.4", md: "4.5rem" };
-
 // ─── Lazy-loaded activity components (one chunk each) ────────────────────────
 const Mechanics2 = lazy(() => import("../../components/Practice/Mechanics2"));
 const Mechanics3 = lazy(() => import("../../components/Practice/Mechanics3"));
@@ -3710,7 +3708,7 @@ const Practice = () => {
                         : "clamp(1.6rem, 2.5vw, 3.8rem)",
                     fontWeight: lang === "te" ? 400 : 700,
                     fontFamily: getFontFamily(lang),
-                    lineHeight: PRACTICE_LINE_HEIGHT,
+                    lineHeight: { xs: 1.4, md: "4.5rem" },
                     background: "#FFF0BD",
                     color: color,
                   }}
@@ -3738,7 +3736,7 @@ const Practice = () => {
                       : "clamp(1.6rem, 2.5vw, 3.8rem)",
                   fontWeight: 700,
                   fontFamily: getFontFamily(lang),
-                  lineHeight: PRACTICE_LINE_HEIGHT,
+                  lineHeight: { xs: 1.4, md: "4.5rem" },
                 }}
               >
                 {i === 0 ? word[i].toUpperCase() : word[i]}
@@ -3767,7 +3765,7 @@ const Practice = () => {
                       : "clamp(1.6rem, 2.5vw, 3.8rem)",
                   fontWeight: 700,
                   fontFamily: getFontFamily(lang),
-                  lineHeight: PRACTICE_LINE_HEIGHT,
+                  lineHeight: { xs: 1.4, md: "4.5rem" },
                   background: "#FFF0BD",
                 }}
               >
@@ -3789,7 +3787,7 @@ const Practice = () => {
                     : "clamp(1.6rem, 2.5vw, 3.8rem)",
                 fontWeight: 700,
                 fontFamily: getFontFamily(lang),
-                lineHeight: PRACTICE_LINE_HEIGHT,
+                lineHeight: { xs: 1.4, md: "4.5rem" },
               }}
               key={index}
             >


### PR DESCRIPTION
ALL-481-hotfix: updated the responsive text line-height for M9 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved highlighted text layout in Practice mode by applying consistent, responsive line spacing across all highlighting scenarios.
  * Updated typography line-height styling to be responsive in Practice/word rendering, preventing inconsistent spacing on different screen sizes.
* **UI/UX**
  * Refined Main layout card padding when screen disabling is enabled, adapting spacing based on showcase mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->