### PR TITLE
Add overrides for @radix-ui/primitive dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "new",
   "version": "0.1.0",
   "private": true,
+  "overrides": {
+    "@radix-ui/primitive": "^1.1.6"
+  },
   "homepage": ".",
   "dependencies": {
     "@ai4bharat/indic-transliterate": "^1.3.8",


### PR DESCRIPTION
CI was failing because the DiscoverSentence test suite could not resolve '@radix-ui/primitive/is-development', imported transitively via @radix-ui/react-slot. Since the workflow deletes package-lock.json before every install and no lockfile is committed, npm could resolve an inconsistent, older copy of @radix-ui/primitive lacking that export. Pinning it via overrides ensures a compatible version (>=1.1.6, which added the is-development conditional export) is always used.