### PR TITLE
Add alias for @radix-ui/primitive in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,8 @@
       "^@number-flow/react$": "<rootDir>/src/__jest_mocks__/number-flow-react.js",
       "^number-flow/csp$": "<rootDir>/src/__jest_mocks__/number-flow-csp.js",
       "^esm-env/(.*)$": "<rootDir>/src/__jest_mocks__/esm-env-browser.js",
-      "^esm-env$": "<rootDir>/src/__jest_mocks__/esm-env.js"
+      "^esm-env$": "<rootDir>/src/__jest_mocks__/esm-env.js",
+      "^@radix-ui/primitive/is-development$": "<rootDir>/node_modules/@radix-ui/primitive/dist/internal/is-development.false.js"
     }
   },
   "eslintConfig": {


### PR DESCRIPTION
The overrides fix (PR #998) alone was insufficient. CRA's bundled Jest (v27) does not honor package.json "exports" maps for conditional subpaths, so it can never resolve '@radix-ui/primitive/is-development' regardless of installed version, since that subpath only exists via the exports map (real files live under dist/internal/is-development.*.js, not a literal is-development.js in the package root). This adds a moduleNameMapper entry, following the same pattern already used in this file for @mui/material and react-router-dom, to redirect that subpath directly to the concrete production build file.