### PR TITLE
ALL-512 :  Fixed the test suite fails by adding a jest.moduleNameMapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,8 @@
       "^@number-flow/react$": "<rootDir>/src/__jest_mocks__/number-flow-react.js",
       "^number-flow/csp$": "<rootDir>/src/__jest_mocks__/number-flow-csp.js",
       "^esm-env/(.*)$": "<rootDir>/src/__jest_mocks__/esm-env-browser.js",
-      "^esm-env$": "<rootDir>/src/__jest_mocks__/esm-env.js"
+      "^esm-env$": "<rootDir>/src/__jest_mocks__/esm-env.js",
+      "^@radix-ui/primitive/is-development$": "<rootDir>/node_modules/@radix-ui/primitive/dist/internal/is-development.false.js"
     }
   },
   "eslintConfig": {


### PR DESCRIPTION
Fix Applied: Added a jest.moduleNameMapper entry in package.json mapping the subpath directly to its resolved file (see [package.json:117-126](vscode-webview://1v7g62ukfcmc5dp794p6mol797g7m43d5geecjr2giidsi2bjf1v/package.json#L117-L126)).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration to consistently mock development-environment checks.
  * Preserved existing environment module mappings for reliable test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->