### PR TITLE
ALL-481-hotfix: Fixed content padding, separate paddingTop for showcase content

### DIFF
--- a/src/components/Layout/MainLayout.jsx
+++ b/src/components/Layout/MainLayout.jsx
@@ -1120,12 +1120,13 @@ const MainLayout = (props) => {
                     overflowY: "hidden",
                     opacity: disableScreen ? 0.25 : 1,
                     pointerEvents: disableScreen ? "none" : "initial",
-                    padding: startShowCase
-                      ? {
-                          xs: "5rem 1rem 1rem !important",
-                          md: "8.125rem 1.5rem 1.5rem !important",
-                        }
-                      : { xs: "1rem !important", md: "1.5rem !important" },
+                    padding: { xs: "1rem !important", md: "1.5rem !important" },
+                    paddingTop:
+                      contentType &&
+                      contentType.toLowerCase() !== "word" &&
+                      startShowCase
+                        ? { xs: "1rem !important", md: "5.625rem !important" }
+                        : { xs: "1rem !important", md: "1.5rem !important" },
                     boxSizing: "border-box",
                     ...props.cardContentStyle,
                   }}

--- a/src/components/Layout/MainLayout.jsx
+++ b/src/components/Layout/MainLayout.jsx
@@ -1120,12 +1120,7 @@ const MainLayout = (props) => {
                     overflowY: "hidden",
                     opacity: disableScreen ? 0.25 : 1,
                     pointerEvents: disableScreen ? "none" : "initial",
-                    padding: startShowCase
-                      ? {
-                          xs: "5rem 1rem 1rem !important",
-                          md: "8.125rem 1.5rem 1.5rem !important",
-                        }
-                      : { xs: "1rem !important", md: "1.5rem !important" },
+                    padding: { xs: "1rem !important", md: "1.5rem !important" },
                     boxSizing: "border-box",
                     ...props.cardContentStyle,
                   }}
@@ -1186,15 +1181,17 @@ const MainLayout = (props) => {
                   contentType.toLowerCase() !== "word" &&
                   startShowCase && (
                     <Box
-                      position={"absolute"}
-                      top={isMobile ? 10 : 20}
-                      left={isMobile ? "initial" : 20}
+                      position={isMobile ? "absolute" : "relative"}
+                      top={isMobile ? 10 : "auto"}
+                      left={isMobile ? "initial" : "auto"}
                       right={isMobile ? 10 : "initial"}
                       justifyContent={"center"}
                       sx={{
                         display: isMobile ? "flex" : "block",
                         flexDirection: isMobile ? "column" : "initial",
                         alignItems: isMobile ? "flex-end" : "initial",
+                        order: isMobile ? "unset" : -1,
+                        padding: isMobile ? 0 : "1.25rem 1.5rem 1rem",
                       }}
                     >
                       <Box display={"flex"} gap={isMobile ? "3px" : "5px"}>

--- a/src/components/Layout/MainLayout.jsx
+++ b/src/components/Layout/MainLayout.jsx
@@ -1120,13 +1120,12 @@ const MainLayout = (props) => {
                     overflowY: "hidden",
                     opacity: disableScreen ? 0.25 : 1,
                     pointerEvents: disableScreen ? "none" : "initial",
-                    padding: { xs: "1rem !important", md: "1.5rem !important" },
-                    paddingTop:
-                      contentType &&
-                      contentType.toLowerCase() !== "word" &&
-                      startShowCase
-                        ? { xs: "1rem !important", md: "5.625rem !important" }
-                        : { xs: "1rem !important", md: "1.5rem !important" },
+                    padding: startShowCase
+                      ? {
+                          xs: "5rem 1rem 1rem !important",
+                          md: "8.125rem 1.5rem 1.5rem !important",
+                        }
+                      : { xs: "1rem !important", md: "1.5rem !important" },
                     boxSizing: "border-box",
                     ...props.cardContentStyle,
                   }}


### PR DESCRIPTION
Splits the top padding from the general padding so only non-"word" content types get the extra top offset during the showcase state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive card spacing and layout.
  * Adjusted showcase spacing to apply only to applicable content types, creating a more consistent visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->