### PR TITLE
ALL-527: Show build version, branch, and commit id in footer badge

### DIFF
--- a/.github/workflows/all-app-sandbox.yml
+++ b/.github/workflows/all-app-sandbox.yml
@@ -102,6 +102,7 @@ jobs:
           REACT_APP_MIN_SCREEN_HEIGHT: ${{ vars.REACT_APP_MIN_SCREEN_HEIGHT }}
           REACT_APP_BUILD_NUMBER: ${{ github.run_number }}
           REACT_APP_COMMIT_ID: ${{ github.sha }}
+          REACT_APP_BRANCH_NAME: ${{ github.ref_name }}
           CI: false # Disabling CI to not treat warnings as errors
         run: npm run build
 

--- a/.github/workflows/all-dev-rig-temp.yml
+++ b/.github/workflows/all-dev-rig-temp.yml
@@ -100,6 +100,7 @@ jobs:
           REACT_APP_MIN_SCREEN_HEIGHT: ${{ vars.REACT_APP_MIN_SCREEN_HEIGHT }}
           REACT_APP_BUILD_NUMBER: ${{ github.run_number }}
           REACT_APP_COMMIT_ID: ${{ github.sha }}
+          REACT_APP_BRANCH_NAME: ${{ github.ref_name }}
           CI: false # Disabling CI to not treat warnings as errors
         run: npm run build
 

--- a/.github/workflows/all-dev-rig.yml
+++ b/.github/workflows/all-dev-rig.yml
@@ -102,6 +102,7 @@ jobs:
           REACT_APP_MIN_SCREEN_HEIGHT: ${{ vars.REACT_APP_MIN_SCREEN_HEIGHT }}
           REACT_APP_BUILD_NUMBER: ${{ github.run_number }}
           REACT_APP_COMMIT_ID: ${{ github.sha }}
+          REACT_APP_BRANCH_NAME: ${{ github.ref_name }}
           CI: false # Disabling CI to not treat warnings as errors
         run: npm run build
 

--- a/.github/workflows/all-dev-tn-new.yml
+++ b/.github/workflows/all-dev-tn-new.yml
@@ -101,6 +101,7 @@ jobs:
           REACT_APP_MIN_SCREEN_HEIGHT: ${{ vars.REACT_APP_MIN_SCREEN_HEIGHT }}
           REACT_APP_BUILD_NUMBER: ${{ github.run_number }}
           REACT_APP_COMMIT_ID: ${{ github.sha }}
+          REACT_APP_BRANCH_NAME: ${{ github.ref_name }}
           CI: false # Disabling CI to not treat warnings as errors
         run: npm run build
 

--- a/.github/workflows/all-dev-tn.yml
+++ b/.github/workflows/all-dev-tn.yml
@@ -101,6 +101,7 @@ jobs:
           REACT_APP_MIN_SCREEN_HEIGHT: ${{ vars.REACT_APP_MIN_SCREEN_HEIGHT }}
           REACT_APP_BUILD_NUMBER: ${{ github.run_number }}
           REACT_APP_COMMIT_ID: ${{ github.sha }}
+          REACT_APP_BRANCH_NAME: ${{ github.ref_name }}
           CI: false # Disabling CI to not treat warnings as errors
         run: npm run build
 

--- a/.github/workflows/all-prod-rig.yml
+++ b/.github/workflows/all-prod-rig.yml
@@ -100,6 +100,7 @@ jobs:
           REACT_APP_MIN_SCREEN_HEIGHT: ${{ vars.REACT_APP_MIN_SCREEN_HEIGHT }}
           REACT_APP_BUILD_NUMBER: ${{ github.run_number }}
           REACT_APP_COMMIT_ID: ${{ github.sha }}
+          REACT_APP_BRANCH_NAME: ${{ github.ref_name }}
           CI: false # Disabling CI to not treat warnings as errors
         run: npm run build
 

--- a/.github/workflows/all-prod-tn-staging.yml
+++ b/.github/workflows/all-prod-tn-staging.yml
@@ -100,6 +100,7 @@ jobs:
           REACT_APP_MIN_SCREEN_HEIGHT: ${{ vars.REACT_APP_MIN_SCREEN_HEIGHT }}
           REACT_APP_BUILD_NUMBER: ${{ github.run_number }}
           REACT_APP_COMMIT_ID: ${{ github.sha }}
+          REACT_APP_BRANCH_NAME: ${{ github.ref_name }}
           CI: false # Disabling CI to not treat warnings as errors
         run: npm run build
 

--- a/.github/workflows/all-prod-tn.yml
+++ b/.github/workflows/all-prod-tn.yml
@@ -98,6 +98,7 @@ jobs:
           REACT_APP_MIN_SCREEN_HEIGHT: ${{ vars.REACT_APP_MIN_SCREEN_HEIGHT }}
           REACT_APP_BUILD_NUMBER: ${{ github.run_number }}
           REACT_APP_COMMIT_ID: ${{ github.sha }}
+          REACT_APP_BRANCH_NAME: ${{ github.ref_name }}
           CI: false  # Disabling CI to not treat warnings as errors
         run: npm run build
 

--- a/.github/workflows/all-staging-tn.yml
+++ b/.github/workflows/all-staging-tn.yml
@@ -104,6 +104,7 @@ jobs:
           REACT_APP_MIN_SCREEN_HEIGHT: ${{ vars.REACT_APP_MIN_SCREEN_HEIGHT }}
           REACT_APP_BUILD_NUMBER: ${{ github.run_number }}
           REACT_APP_COMMIT_ID: ${{ github.sha }}
+          REACT_APP_BRANCH_NAME: ${{ github.ref_name }}
           CI: false # Disabling CI to not treat warnings as errors
         run: npm run build
 

--- a/.github/workflows/all-temp-staging .yml
+++ b/.github/workflows/all-temp-staging .yml
@@ -99,6 +99,7 @@ jobs:
           REACT_APP_MIN_SCREEN_HEIGHT: ${{ vars.REACT_APP_MIN_SCREEN_HEIGHT }}
           REACT_APP_BUILD_NUMBER: ${{ github.run_number }}
           REACT_APP_COMMIT_ID: ${{ github.sha }}
+          REACT_APP_BRANCH_NAME: ${{ github.ref_name }}
           CI: false # Disabling CI to not treat warnings as errors
         run: npm run build
 

--- a/.github/workflows/axl-bihar-rig.yml
+++ b/.github/workflows/axl-bihar-rig.yml
@@ -101,6 +101,7 @@ jobs:
           REACT_APP_MIN_SCREEN_HEIGHT: ${{ vars.REACT_APP_MIN_SCREEN_HEIGHT }}
           REACT_APP_BUILD_NUMBER: ${{ github.run_number }}
           REACT_APP_COMMIT_ID: ${{ github.sha }}
+          REACT_APP_BRANCH_NAME: ${{ github.ref_name }}
           PUBLIC_URL: ${{ vars.PUBLIC_URL }}
           CI: false # Disabling CI to not treat warnings as errors
         run: npm run build

--- a/.github/workflows/axl-dev-rig.yml
+++ b/.github/workflows/axl-dev-rig.yml
@@ -101,6 +101,7 @@ jobs:
           REACT_APP_MIN_SCREEN_HEIGHT: ${{ vars.REACT_APP_MIN_SCREEN_HEIGHT }}
           REACT_APP_BUILD_NUMBER: ${{ github.run_number }}
           REACT_APP_COMMIT_ID: ${{ github.sha }}
+          REACT_APP_BRANCH_NAME: ${{ github.ref_name }}
           PUBLIC_URL: ${{ vars.PUBLIC_URL }}
           CI: false # Disabling CI to not treat warnings as errors
         run: npm run build

--- a/.github/workflows/axl_lab1.yml
+++ b/.github/workflows/axl_lab1.yml
@@ -101,6 +101,7 @@ jobs:
           REACT_APP_MIN_SCREEN_HEIGHT: ${{ vars.REACT_APP_MIN_SCREEN_HEIGHT }}
           REACT_APP_BUILD_NUMBER: ${{ github.run_number }}
           REACT_APP_COMMIT_ID: ${{ github.sha }}
+          REACT_APP_BRANCH_NAME: ${{ github.ref_name }}
           CI: false # Disabling CI to not treat warnings as errors
         run: npm run build
 

--- a/src/App.js
+++ b/src/App.js
@@ -528,7 +528,9 @@ const App = () => {
             padding: "2px 6px",
           }}
         >
-          Build #{process.env.REACT_APP_BUILD_NUMBER} &middot;{" "}
+          v{process.env.REACT_APP_VER} &middot; Build #
+          {process.env.REACT_APP_BUILD_NUMBER} &middot;{" "}
+          {process.env.REACT_APP_BRANCH_NAME || "dev"} &middot;{" "}
           {process.env.REACT_APP_COMMIT_ID?.substring(0, 7) || "dev"}
         </span>
       )}


### PR DESCRIPTION
Extend the build info badge in App.js to display REACT_APP_VER and REACT_APP_BRANCH_NAME alongside the existing build number and commit id. Add REACT_APP_BRANCH_NAME injection (github.ref_name) to all 13 CI/CD workflows.