### PR TITLE
ALL-529 : Remove Milestone 10 and Milestone 11 Images from Mobile View M9 dashboard 

### DIFF
--- a/src/components/Assesment/Assesment.jsx
+++ b/src/components/Assesment/Assesment.jsx
@@ -73,7 +73,7 @@ import desktopLevel5Mobile from "../../assets/images/mobilebglevel5.png";
 import desktopLevel6Mobile from "../../assets/images/mobilebglevel6.png";
 import desktopLevel7Mobile from "../../assets/images/mobilebglevel7.png";
 import desktopLevel8Mobile from "../../assets/images/mobilebglevel8.png";
-import desktopLevel9Mobile from "../../assets/images/mobilebglevel10.png";
+import desktopLevel9Mobile from "../../assets/images/desktopLevel9.png";
 import desktopLevel10Mobile from "../../assets/images/mobilebglevel10.png";
 import rOneImage from "../../assets/R1Back.png";
 import rTwoImage from "../../assets/R2Back.png";

--- a/src/components/Assesment/Assesment.jsx
+++ b/src/components/Assesment/Assesment.jsx
@@ -2204,8 +2204,9 @@ const Assesment = ({ discoverStart }) => {
     height: "100dvh",
     minHeight: "-webkit-fill-available",
     backgroundImage: `url(${getBackgroundImage()})`,
-    backgroundSize: "100% 100%",
+    backgroundSize: isMobile ? "cover" : "100% 100%",
     backgroundRepeat: "no-repeat",
+    backgroundPosition: isMobile ? "35% bottom" : "center",
     position: "relative",
   };
 

--- a/src/components/Assesment/Assesment.jsx
+++ b/src/components/Assesment/Assesment.jsx
@@ -73,7 +73,6 @@ import desktopLevel5Mobile from "../../assets/images/mobilebglevel5.png";
 import desktopLevel6Mobile from "../../assets/images/mobilebglevel6.png";
 import desktopLevel7Mobile from "../../assets/images/mobilebglevel7.png";
 import desktopLevel8Mobile from "../../assets/images/mobilebglevel8.png";
-import desktopLevel9Mobile from "../../assets/images/desktopLevel9.png";
 import desktopLevel10Mobile from "../../assets/images/mobilebglevel10.png";
 import rOneImage from "../../assets/R1Back.png";
 import rTwoImage from "../../assets/R2Back.png";
@@ -2119,7 +2118,7 @@ const Assesment = ({ discoverStart }) => {
     desktopLevel6Mobile,
     desktopLevel7Mobile,
     desktopLevel8Mobile,
-    desktopLevel9Mobile,
+    desktopLevel9Mobile: desktopLevel9,
     desktopLevel10Mobile,
   };
 


### PR DESCRIPTION
Updated the M9 (Level 9) mobile background image import in Assesment.jsx to use desktopLevel9.png.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the assessment background image displayed for the relevant desktop and mobile layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->