### PR TITLE
ALL-557 : Added auto-scroll MCQ panel on option select, mic, and Next click - Mechanic5

### DIFF
--- a/src/components/Practice/Mechanics5.jsx
+++ b/src/components/Practice/Mechanics5.jsx
@@ -134,13 +134,20 @@ const Mechanics5 = ({
 
   // Only called from click handlers below - never on mount/page load - so the
   // panel never auto-scrolls until the user's own click introduces overflow.
+  // scrollGenerationRef lets scrollUpToTop invalidate an in-flight downward
+  // scroll (queued via the double rAF below) so a fast Next click can't be
+  // undone by a stale scroll-to-bottom callback firing after it.
+  const scrollGenerationRef = useRef(0);
+
   const scrollDownIfOverflowing = () => {
+    const generation = ++scrollGenerationRef.current;
     const container = scrollContainerRef.current;
     if (!container) return;
     // Wait two frames so the click's re-render has finished laying out
     // before we measure the container's height.
     requestAnimationFrame(() => {
       requestAnimationFrame(() => {
+        if (generation !== scrollGenerationRef.current) return;
         if (container.scrollHeight > container.clientHeight) {
           container.scrollTo({
             top: container.scrollHeight,
@@ -152,6 +159,7 @@ const Mechanics5 = ({
   };
 
   const scrollUpToTop = () => {
+    scrollGenerationRef.current += 1;
     const container = scrollContainerRef.current;
     if (!container) return;
     container.scrollTo({ top: 0, behavior: "smooth" });

--- a/src/components/Practice/Mechanics5.jsx
+++ b/src/components/Practice/Mechanics5.jsx
@@ -65,6 +65,7 @@ const Mechanics5 = ({
     new Array(options.length).fill(null).map(() => React.createRef())
   );
   const questionAudioRef = useRef();
+  const scrollContainerRef = useRef(null);
   const [playingIndex, setPlayingIndex] = useState(null);
   const [selectedOption, setSelectedOption] = useState(null); // Add state to track selected radio button
   const lang = getLocalData("lang");
@@ -131,9 +132,45 @@ const Mechanics5 = ({
 
   //console.log('Mechanics5' , storedData, options);
 
+  // Only called from click handlers below - never on mount/page load - so the
+  // panel never auto-scrolls until the user's own click introduces overflow.
+  const scrollDownIfOverflowing = () => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+    // Wait two frames so the click's re-render has finished laying out
+    // before we measure the container's height.
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        if (container.scrollHeight > container.clientHeight) {
+          container.scrollTo({
+            top: container.scrollHeight,
+            behavior: "smooth",
+          });
+        }
+      });
+    });
+  };
+
+  const scrollUpToTop = () => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+    container.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
   const handleOptionChange = (event, i) => {
     setSelectedOption(i); // Set the selected option index
+    scrollDownIfOverflowing();
   };
+
+  // The orange Next button is the only caller that passes `true` here;
+  // internal ASR-processing effects reset it back to `false`, which must
+  // not scroll (e.g. right after the user clicks the red stop button).
+  const setIsNextButtonCalledWithScroll = setIsNextButtonCalled
+    ? (value) => {
+        if (value) scrollUpToTop();
+        setIsNextButtonCalled(value);
+      }
+    : undefined;
 
   return (
     <MainLayout
@@ -216,6 +253,7 @@ const Mechanics5 = ({
         </Box>
 
         <Box
+          ref={scrollContainerRef}
           sx={{
             flex: 1,
             minHeight: 0,
@@ -454,6 +492,7 @@ const Mechanics5 = ({
               }
               enableNext={enableNext}
               handleNext={handleNext}
+              handleStartRecording={scrollDownIfOverflowing}
               selectedOption={options[selectedOption]}
               correctness={correctness}
               audioLink={audio ? audio : null}
@@ -475,7 +514,7 @@ const Mechanics5 = ({
                 loading,
                 setLivesData,
                 isNextButtonCalled,
-                setIsNextButtonCalled,
+                setIsNextButtonCalled: setIsNextButtonCalledWithScroll,
               }}
             />
           </Box>

--- a/src/components/Practice/Mechanics5.jsx
+++ b/src/components/Practice/Mechanics5.jsx
@@ -12,6 +12,45 @@ import ZoomableImage from "./ZoomableImage";
 import { getFontFamily } from "../../utils/fontUtils";
 import { getUiStrings } from "../../constants/strings";
 
+// Scrolls the MCQ panel down when new content overflows it (radio select,
+// mic start) and back to top when the user advances via Next. Extracted out
+// of Mechanics5 so this control flow doesn't count toward its complexity.
+// scrollGenerationRef lets scrollUpToTop invalidate an in-flight downward
+// scroll (queued via the double rAF below) so a fast Next click can't be
+// undone by a stale scroll-to-bottom callback firing after it.
+const useMcqAutoScroll = () => {
+  const scrollContainerRef = useRef(null);
+  const scrollGenerationRef = useRef(0);
+
+  const scrollDownIfOverflowing = () => {
+    const generation = ++scrollGenerationRef.current;
+    const container = scrollContainerRef.current;
+    if (!container) return;
+    // Wait two frames so the click's re-render has finished laying out
+    // before we measure the container's height.
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        if (generation !== scrollGenerationRef.current) return;
+        if (container.scrollHeight > container.clientHeight) {
+          container.scrollTo({
+            top: container.scrollHeight,
+            behavior: "smooth",
+          });
+        }
+      });
+    });
+  };
+
+  const scrollUpToTop = () => {
+    scrollGenerationRef.current += 1;
+    const container = scrollContainerRef.current;
+    if (!container) return;
+    container.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
+  return { scrollContainerRef, scrollDownIfOverflowing, scrollUpToTop };
+};
+
 const Mechanics5 = ({
   background,
   type,
@@ -65,7 +104,8 @@ const Mechanics5 = ({
     new Array(options.length).fill(null).map(() => React.createRef())
   );
   const questionAudioRef = useRef();
-  const scrollContainerRef = useRef(null);
+  const { scrollContainerRef, scrollDownIfOverflowing, scrollUpToTop } =
+    useMcqAutoScroll();
   const [playingIndex, setPlayingIndex] = useState(null);
   const [selectedOption, setSelectedOption] = useState(null); // Add state to track selected radio button
   const lang = getLocalData("lang");
@@ -131,39 +171,6 @@ const Mechanics5 = ({
   };
 
   //console.log('Mechanics5' , storedData, options);
-
-  // Only called from click handlers below - never on mount/page load - so the
-  // panel never auto-scrolls until the user's own click introduces overflow.
-  // scrollGenerationRef lets scrollUpToTop invalidate an in-flight downward
-  // scroll (queued via the double rAF below) so a fast Next click can't be
-  // undone by a stale scroll-to-bottom callback firing after it.
-  const scrollGenerationRef = useRef(0);
-
-  const scrollDownIfOverflowing = () => {
-    const generation = ++scrollGenerationRef.current;
-    const container = scrollContainerRef.current;
-    if (!container) return;
-    // Wait two frames so the click's re-render has finished laying out
-    // before we measure the container's height.
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
-        if (generation !== scrollGenerationRef.current) return;
-        if (container.scrollHeight > container.clientHeight) {
-          container.scrollTo({
-            top: container.scrollHeight,
-            behavior: "smooth",
-          });
-        }
-      });
-    });
-  };
-
-  const scrollUpToTop = () => {
-    scrollGenerationRef.current += 1;
-    const container = scrollContainerRef.current;
-    if (!container) return;
-    container.scrollTo({ top: 0, behavior: "smooth" });
-  };
 
   const handleOptionChange = (event, i) => {
     setSelectedOption(i); // Set the selected option index


### PR DESCRIPTION
Fix Implemented:
Implemented automatic scrolling to ensure the action buttons remain visible whenever the content overflows the panel.

The panel now automatically scrolls down when an option is selected or recording starts, bringing the Mic, Play, Replay, and Next buttons into view.

On clicking Next, the panel automatically scrolls back to the top for the next question.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved scrolling in the practice options panel.
  * Selecting an option or starting a recording now moves to the latest content when needed.
  * Using the **Next** button returns the panel to the top for easier navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->