### PR TITLE
ALL-580: hotfix -fixed  the text is getting cut from top

### DIFF
--- a/src/components/Mechanism/WordsOrImage.jsx
+++ b/src/components/Mechanism/WordsOrImage.jsx
@@ -775,6 +775,9 @@ const WordsOrImage = ({
           pointerEvents: disableScreen ? "none" : "initial",
           display: "flex",
           flexDirection: "column",
+          // "flex-start" + marginTop/marginBottom: "auto" below (safe-center):
+          // centers this content when it fits, but pins it to the top and stays
+          // scrollable instead of clipping/hiding content when it overflows.
           justifyContent: "flex-start",
           alignItems: "center",
           flexGrow: 1,
@@ -788,7 +791,7 @@ const WordsOrImage = ({
       >
         <Box
           sx={{
-            marginTop: "auto",
+            marginTop: "auto", // safe-center; pairs with marginBottom "auto" below
             width: { xs: "100%", md: "auto" },
             maxWidth: "100%",
           }}
@@ -1375,7 +1378,7 @@ const WordsOrImage = ({
             justifyContent: "center",
             alignItems: "center",
             minHeight: "22vh",
-            marginBottom: "auto",
+            marginBottom: "auto", // safe-center; pairs with marginTop "auto" on the paragraph box above
             mt: isMobile ? 2 : 0,
           }}
         >

--- a/src/components/Mechanism/WordsOrImage.jsx
+++ b/src/components/Mechanism/WordsOrImage.jsx
@@ -713,8 +713,8 @@ const WordsOrImage = ({
             : "center",
         alignItems: "center",
         height: "100%",
-        overflowX: "hidden",
-        overflowY: "hidden",
+        overflowX: "auto",
+        overflowY: "auto",
       }}
       {...{
         steps,
@@ -770,26 +770,29 @@ const WordsOrImage = ({
       </Box>
       <CardContent
         sx={{
-          overflow: isDemo ? "visible" : "hidden",
+          overflowX: isDemo ? "visible" : "auto",
           opacity: disableScreen ? 0.25 : 1,
           pointerEvents: disableScreen ? "none" : "initial",
           display: "flex",
           flexDirection: "column",
-          justifyContent:
-            startShowCase && !isDemo
-              ? { xs: "center", md: "flex-start" }
-              : "center",
+          justifyContent: "flex-start",
           alignItems: "center",
           flexGrow: 1,
           pt: { xs: "24px", md: "0px" },
           pb: { xs: "0px", md: "16px" },
-          overflowY: { xs: "auto", md: "hidden" },
+          overflowY: isDemo ? "visible" : "auto",
           boxSizing: "border-box",
           height: "100%",
           width: "100%",
         }}
       >
-        <Box sx={{ width: { xs: "100%", md: "auto" } }}>
+        <Box
+          sx={{
+            marginTop: "auto",
+            width: { xs: "100%", md: "auto" },
+            maxWidth: "100%",
+          }}
+        >
           {type === "image" ? (
             <Box sx={{ display: "flex", justifyContent: "center" }}>
               <img
@@ -1370,6 +1373,9 @@ const WordsOrImage = ({
           sx={{
             display: "flex",
             justifyContent: "center",
+            alignItems: "center",
+            minHeight: "22vh",
+            marginBottom: "auto",
             mt: isMobile ? 2 : 0,
           }}
         >

--- a/src/components/Mechanism/WordsOrImage.jsx
+++ b/src/components/Mechanism/WordsOrImage.jsx
@@ -775,9 +775,6 @@ const WordsOrImage = ({
           pointerEvents: disableScreen ? "none" : "initial",
           display: "flex",
           flexDirection: "column",
-          // "flex-start" + marginTop/marginBottom: "auto" below (safe-center):
-          // centers this content when it fits, but pins it to the top and stays
-          // scrollable instead of clipping/hiding content when it overflows.
           justifyContent: "flex-start",
           alignItems: "center",
           flexGrow: 1,
@@ -791,7 +788,7 @@ const WordsOrImage = ({
       >
         <Box
           sx={{
-            marginTop: "auto", // safe-center; pairs with marginBottom "auto" below
+            marginTop: "auto",
             width: { xs: "100%", md: "auto" },
             maxWidth: "100%",
           }}
@@ -1378,7 +1375,7 @@ const WordsOrImage = ({
             justifyContent: "center",
             alignItems: "center",
             minHeight: "22vh",
-            marginBottom: "auto", // safe-center; pairs with marginTop "auto" on the paragraph box above
+            marginBottom: "auto",
             mt: isMobile ? 2 : 0,
           }}
         >

--- a/src/components/Mechanism/WordsOrImage.jsx
+++ b/src/components/Mechanism/WordsOrImage.jsx
@@ -713,8 +713,8 @@ const WordsOrImage = ({
             : "center",
         alignItems: "center",
         height: "100%",
-        overflowX: "auto",
-        overflowY: "auto",
+        overflowX: "hidden",
+        overflowY: "hidden",
       }}
       {...{
         steps,

--- a/src/views/Practice/Practice.jsx
+++ b/src/views/Practice/Practice.jsx
@@ -3787,7 +3787,7 @@ const Practice = () => {
                     : "clamp(1.6rem, 2.5vw, 3.8rem)",
                 fontWeight: 700,
                 fontFamily: getFontFamily(lang),
-                lineHeight: { xs: 1.4, md: "4.5rem" },
+                lineHeight: { xs: 1.5, sm: 2, md: 1.5 },
               }}
               key={index}
             >


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Content can now be scrolled horizontally and vertically when it exceeds the available space.
  * Demo displays content without clipping, while regular mode provides automatic scrolling as needed.
  * Content begins at the top of the available area for easier viewing.
  * Recording controls now remain centered with more consistent spacing and minimum height.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->