### PR TITLE
All-587 : 3.0.7 -Incorrect audio buttons text is shown in wordwall and wrong audio is played in telanganas instance for telugu langauge

### DIFF
--- a/src/components/Practice/WordWall.jsx
+++ b/src/components/Practice/WordWall.jsx
@@ -1216,11 +1216,13 @@ const WordWall = ({
                   alt="Listen"
                   style={{ height: isMobile ? "26px" : "40px" }}
                 />
-                <span>{ui.WORD_WALL_LISTEN_ENGLISH}</span>
+                <span>
+                  {AllLanguages.find((l) => l.lang === lang)?.name || "English"}
+                </span>
               </div>
               <div
                 style={{
-                  display: "flex",
+                  display: currentAnswer?.audio_hi ? "flex" : "none",
                   alignItems: "center",
                   gap: isMobile ? "4px" : "8px",
                   cursor: "pointer",

--- a/src/components/Practice/WordWall.jsx
+++ b/src/components/Practice/WordWall.jsx
@@ -1216,35 +1216,39 @@ const WordWall = ({
                   alt="Listen"
                   style={{ height: isMobile ? "26px" : "40px" }}
                 />
-                <span>{ui.WORD_WALL_LISTEN_ENGLISH}</span>
+                <span>
+                  {AllLanguages.find((l) => l.lang === lang)?.name || "English"}
+                </span>
               </div>
-              <div
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  gap: isMobile ? "4px" : "8px",
-                  cursor: "pointer",
-                  color: "#333F61",
-                  padding: isMobile ? "6px 8px" : "8px 12px",
-                  borderRadius: "20px",
-                  fontFamily: "Quicksand",
-                  fontWeight: 800,
-                  minHeight: isMobile ? "36px" : "44px",
-                  fontSize: isMobile ? "13px" : "inherit",
-                }}
-                onClick={() =>
-                  playAudio(
-                    `${process.env.REACT_APP_AWS_S3_BUCKET_CONTENT_URL}/multilingual_audios/${currentAnswer?.audio_hi}`
-                  )
-                }
-              >
-                <img
-                  src={listenvioletImg}
-                  alt="Listen"
-                  style={{ height: isMobile ? "26px" : "40px" }}
-                />
-                <span>{nativeLangLabel}</span>
-              </div>
+              {currentAnswer?.audio_hi && (
+                <div
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: isMobile ? "4px" : "8px",
+                    cursor: "pointer",
+                    color: "#333F61",
+                    padding: isMobile ? "6px 8px" : "8px 12px",
+                    borderRadius: "20px",
+                    fontFamily: "Quicksand",
+                    fontWeight: 800,
+                    minHeight: isMobile ? "36px" : "44px",
+                    fontSize: isMobile ? "13px" : "inherit",
+                  }}
+                  onClick={() =>
+                    playAudio(
+                      `${process.env.REACT_APP_AWS_S3_BUCKET_CONTENT_URL}/multilingual_audios/${currentAnswer?.audio_hi}`
+                    )
+                  }
+                >
+                  <img
+                    src={listenvioletImg}
+                    alt="Listen"
+                    style={{ height: isMobile ? "26px" : "40px" }}
+                  />
+                  <span>{nativeLangLabel}</span>
+                </div>
+              )}
             </div>
           </div>
 


### PR DESCRIPTION
Description
ALL-587: Fix Word Wall audio buttons and labels for non-English languages

Problem: In the Word Wall review screen, the primary audio button was hardcoded to display "Listen in English," which is misleading and incorrect when learning other languages (like Telugu). Additionally, the secondary "help language" translation button was being rendered unconditionally, resulting in a broken, silent button when translation audio data was unavailable in the database.

Solution:

Updated the primary button label to dynamically display the name of the current learning language (e.g., "English", "తెలుగు") based on the lang parameter, removing the hardcoded string.
Added conditional rendering to the secondary multilingual audio button so it is only displayed if the corresponding translation audio data (audio_hi) exists for that word.
Impact:

The Word Wall now correctly labels the primary audio button for the language being learned.
The UI is cleaner and prevents users from clicking on a broken translation button when no data is available from the backend.